### PR TITLE
feat: add configuration validation and TOML handling (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ ty check src
 ruff check src
 ```
 
+## 開発状況
+
+### Phase 1: Core 実装 🚧
+
+| モジュール | 状態 | テスト |
+|-----------|------|--------|
+| models.py | ✅ 完了 | 34/34 パス |
+| config.py | ✅ 完了 | 55/55 パス |
+| api.py | ⏳ 未実装 | - |
+| downloader.py | ⏳ 未実装 | - |
+| manager.py | ⏳ 未実装 | - |
+
+**完了した機能**: F-101～F-107（設定管理機能 7件）
+
 ## ドキュメント
 
 ### 要件定義（「はじめよう！要件定義」準拠）
@@ -119,13 +133,16 @@ ruff check src
 - [実現したいこと一覧](docs/03_requirements_list.md)
 - [行動シナリオ](docs/04_user_scenarios.md)
 - [概念データモデル](docs/05_conceptual_data_model.md)
+- [UI 定義](docs/06_ui_definition.md)
+- [機能定義](docs/07_function_definition.md)
+- [データ定義](docs/08_data_definition.md)
+- [CRUD マトリックス](docs/09_crud_matrix.md)
+- [一覧](docs/10_summary.md)
+- [アーキテクチャ設計書](docs/11_architecture.md)
 
 ### 技術ドキュメント
 
-- [要件定義書](docs/requirements.md)
-- [アーキテクチャ設計書](docs/architecture.md)
 - [Modrinth API 仕様メモ](docs/modrinth-api.md)
-- [開発ロードマップ](docs/roadmap.md)
 
 ## ライセンス
 

--- a/docs/10_summary.md
+++ b/docs/10_summary.md
@@ -223,11 +223,13 @@
 | パッケージ管理 | uv |
 | 型チェック | ty |
 | リンター | ruff |
-| テスト | pytest |
+| テスト | pytest, pytest-asyncio, pytest-httpx |
 | HTTP クライアント | httpx |
 | CLI フレームワーク | typer |
 | TUI フレームワーク | textual（将来） |
 | 出力装飾 | rich |
+| TOML 処理 | tomllib (stdlib), tomlkit |
+| バリデーション | pydantic |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "typer>=0.12",
     "rich>=13.0",
     "pydantic>=2.0",
+    "tomlkit>=0.12",
 ]
 
 [project.optional-dependencies]

--- a/src/mcpax/core/config.py
+++ b/src/mcpax/core/config.py
@@ -1,1 +1,283 @@
 """Configuration file handling."""
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomlkit
+
+from .models import AppConfig, Loader, ProjectConfig, ReleaseChannel
+
+# Constants
+DEFAULT_CONFIG_PATH = Path("./config.toml")
+DEFAULT_PROJECTS_PATH = Path("./projects.toml")
+MINECRAFT_VERSION_PATTERN = re.compile(r"^\d+\.\d+(\.\d+)?(-\w+)?$")
+
+
+@dataclass
+class ValidationError:
+    """A single validation error."""
+
+    field: str
+    message: str
+
+
+class ConfigValidationError(Exception):
+    """Configuration validation failed."""
+
+    def __init__(self, message: str, errors: list[ValidationError] | None = None):
+        super().__init__(message)
+        self.errors = errors or []
+
+
+def resolve_path(path: str | Path) -> Path:
+    """Expand ~ and relative paths to absolute.
+
+    Args:
+        path: Path string or Path object
+
+    Returns:
+        Absolute Path object
+    """
+    return Path(path).expanduser().resolve()
+
+
+def load_config(path: Path | None = None) -> AppConfig:
+    """Load config.toml and return AppConfig.
+
+    Args:
+        path: Path to config file (defaults to ./config.toml)
+
+    Returns:
+        AppConfig instance
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist
+        ConfigValidationError: If config is invalid
+    """
+    config_path = path or DEFAULT_CONFIG_PATH
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    try:
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigValidationError(f"Invalid TOML: {e}") from e
+
+    # Extract values from TOML structure
+    minecraft = data.get("minecraft", {})
+    paths = data.get("paths", {})
+    download = data.get("download", {})
+
+    try:
+        return AppConfig(
+            minecraft_version=minecraft["version"],
+            loader=Loader(minecraft["loader"]),
+            minecraft_dir=resolve_path(paths["minecraft_dir"]),
+            mods_dir=(
+                resolve_path(paths["mods_dir"]) if paths.get("mods_dir") else None
+            ),
+            shaders_dir=(
+                resolve_path(paths["shaders_dir"]) if paths.get("shaders_dir") else None
+            ),
+            resourcepacks_dir=(
+                resolve_path(paths["resourcepacks_dir"])
+                if paths.get("resourcepacks_dir")
+                else None
+            ),
+            max_concurrent_downloads=download.get("max_concurrent", 5),
+            verify_hash=download.get("verify_hash", True),
+        )
+    except KeyError as e:
+        raise ConfigValidationError(f"Missing required field: {e}") from e
+    except ValueError as e:
+        raise ConfigValidationError(f"Invalid value: {e}") from e
+
+
+def generate_config(
+    minecraft_version: str,
+    loader: Loader,
+    minecraft_dir: Path,
+    path: Path | None = None,
+    force: bool = False,
+) -> Path:
+    """Generate config.toml.
+
+    Args:
+        minecraft_version: Minecraft version (e.g., "1.21.4")
+        loader: Mod loader type
+        minecraft_dir: Path to .minecraft directory
+        path: Output path (defaults to ./config.toml)
+        force: Overwrite existing file
+
+    Returns:
+        Path to created config file
+
+    Raises:
+        FileExistsError: If file exists and force=False
+    """
+    config_path = path or DEFAULT_CONFIG_PATH
+
+    if config_path.exists() and not force:
+        raise FileExistsError(f"Config file already exists: {config_path}")
+
+    doc = tomlkit.document()
+
+    minecraft = tomlkit.table()
+    minecraft.add("version", minecraft_version)
+    minecraft.add("loader", loader.value)
+    doc.add("minecraft", minecraft)
+
+    paths = tomlkit.table()
+    paths.add("minecraft_dir", str(minecraft_dir))
+    doc.add("paths", paths)
+
+    download = tomlkit.table()
+    download.add("max_concurrent", 5)
+    download.add("verify_hash", True)
+    doc.add("download", download)
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        f.write(tomlkit.dumps(doc))
+
+    return config_path
+
+
+def load_projects(path: Path | None = None) -> list[ProjectConfig]:
+    """Load projects.toml and return list of ProjectConfig.
+
+    Args:
+        path: Path to projects file (defaults to ./projects.toml)
+
+    Returns:
+        List of ProjectConfig instances
+
+    Raises:
+        FileNotFoundError: If projects file doesn't exist
+        ConfigValidationError: If projects file is invalid
+    """
+    projects_path = path or DEFAULT_PROJECTS_PATH
+
+    if not projects_path.exists():
+        raise FileNotFoundError(f"Projects file not found: {projects_path}")
+
+    try:
+        with open(projects_path, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigValidationError(f"Invalid TOML: {e}") from e
+
+    projects_data = data.get("projects", [])
+    try:
+        return [
+            ProjectConfig(
+                slug=p["slug"],
+                version=p.get("version"),
+                channel=ReleaseChannel(p.get("channel", "release")),
+            )
+            for p in projects_data
+        ]
+    except KeyError as e:
+        raise ConfigValidationError(f"Missing required field in project: {e}") from e
+    except ValueError as e:
+        raise ConfigValidationError(f"Invalid value in project: {e}") from e
+
+
+def generate_projects(path: Path | None = None, force: bool = False) -> Path:
+    """Generate empty projects.toml.
+
+    Args:
+        path: Output path (defaults to ./projects.toml)
+        force: Overwrite existing file
+
+    Returns:
+        Path to created projects file
+
+    Raises:
+        FileExistsError: If file exists and force=False
+    """
+    projects_path = path or DEFAULT_PROJECTS_PATH
+
+    if projects_path.exists() and not force:
+        raise FileExistsError(f"Projects file already exists: {projects_path}")
+
+    doc = tomlkit.document()
+    doc.add(tomlkit.comment("Managed projects"))
+    doc.add(tomlkit.nl())
+    doc.add(tomlkit.comment("Example:"))
+    doc.add(tomlkit.comment("[[projects]]"))
+    doc.add(tomlkit.comment('slug = "fabric-api"'))
+
+    with open(projects_path, "w", encoding="utf-8") as f:
+        f.write(tomlkit.dumps(doc))
+
+    return projects_path
+
+
+def save_projects(projects: list[ProjectConfig], path: Path | None = None) -> Path:
+    """Save list of ProjectConfig to projects.toml.
+
+    Args:
+        projects: List of ProjectConfig instances
+        path: Output path (defaults to ./projects.toml)
+
+    Returns:
+        Path to saved projects file
+    """
+    projects_path = path or DEFAULT_PROJECTS_PATH
+
+    doc = tomlkit.document()
+
+    if projects:
+        aot = tomlkit.aot()
+        for project in projects:
+            table = tomlkit.table()
+            table.add("slug", project.slug)
+            if project.version is not None:
+                table.add("version", project.version)
+            if project.channel != ReleaseChannel.RELEASE:
+                table.add("channel", project.channel.value)
+
+            aot.append(table)
+
+        doc.add("projects", aot)
+
+    with open(projects_path, "w", encoding="utf-8") as f:
+        f.write(tomlkit.dumps(doc))
+
+    return projects_path
+
+
+def validate_config(config: AppConfig) -> list[ValidationError]:
+    """Validate AppConfig values.
+
+    Args:
+        config: AppConfig instance to validate
+
+    Returns:
+        List of ValidationError (empty if valid)
+    """
+    errors: list[ValidationError] = []
+
+    # Validate minecraft_version format
+    if not MINECRAFT_VERSION_PATTERN.match(config.minecraft_version):
+        errors.append(
+            ValidationError(
+                field="minecraft_version",
+                message=f"Invalid version format: {config.minecraft_version}",
+            )
+        )
+
+    # Validate minecraft_dir exists
+    if not config.minecraft_dir.exists():
+        errors.append(
+            ValidationError(
+                field="minecraft_dir",
+                message=f"Directory does not exist: {config.minecraft_dir}",
+            )
+        )
+
+    return errors

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,884 @@
+"""Tests for mcpax.core.config."""
+
+from pathlib import Path
+
+import pytest
+
+from mcpax.core.config import (
+    ConfigValidationError,
+    ValidationError,
+    generate_config,
+    generate_projects,
+    load_config,
+    load_projects,
+    resolve_path,
+    save_projects,
+    validate_config,
+)
+from mcpax.core.models import AppConfig, Loader, ProjectConfig, ReleaseChannel
+
+
+class TestResolvePath:
+    """Tests for resolve_path function."""
+
+    def test_expand_tilde(self) -> None:
+        """resolve_path expands ~ to home directory."""
+        # Arrange
+        home = Path.home()
+
+        # Act
+        result = resolve_path("~")
+
+        # Assert
+        assert result == home
+        assert result.is_absolute()
+
+    def test_expand_tilde_with_subdirectory(self) -> None:
+        """resolve_path expands ~/subdir correctly."""
+        # Arrange
+        home = Path.home()
+
+        # Act
+        result = resolve_path("~/subdir")
+
+        # Assert
+        assert result == home / "subdir"
+        assert result.is_absolute()
+
+    def test_relative_path_to_absolute(self, tmp_path: Path) -> None:
+        """resolve_path converts relative path to absolute."""
+        # Arrange
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+
+        try:
+            # Act
+            result = resolve_path("./relative")
+
+            # Assert
+            assert result == tmp_path / "relative"
+            assert result.is_absolute()
+        finally:
+            os.chdir(original_cwd)
+
+    def test_absolute_path_unchanged(self, tmp_path: Path) -> None:
+        """resolve_path returns absolute path as-is."""
+        # Arrange
+        absolute = tmp_path / "absolute"
+
+        # Act
+        result = resolve_path(absolute)
+
+        # Assert
+        assert result == absolute
+        assert result.is_absolute()
+
+    def test_string_input(self) -> None:
+        """resolve_path accepts string input."""
+        # Arrange
+        path_str = "~/test"
+
+        # Act
+        result = resolve_path(path_str)
+
+        # Assert
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+
+    def test_path_input(self) -> None:
+        """resolve_path accepts Path input."""
+        # Arrange
+        path_obj = Path("~/test")
+
+        # Act
+        result = resolve_path(path_obj)
+
+        # Assert
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+
+
+class TestValidationError:
+    """Tests for ValidationError class."""
+
+    def test_stores_field_and_message(self) -> None:
+        """ValidationError stores field name and message."""
+        # Arrange & Act
+        error = ValidationError(field="test_field", message="test message")
+
+        # Assert
+        assert error.field == "test_field"
+        assert error.message == "test message"
+
+
+class TestConfigValidationError:
+    """Tests for ConfigValidationError class."""
+
+    def test_inherits_from_exception(self) -> None:
+        """ConfigValidationError inherits from Exception."""
+        # Arrange & Act
+        error = ConfigValidationError("test")
+
+        # Assert
+        assert isinstance(error, Exception)
+
+    def test_stores_message(self) -> None:
+        """ConfigValidationError stores error message."""
+        # Arrange & Act
+        error = ConfigValidationError("test message")
+
+        # Assert
+        assert str(error) == "test message"
+
+    def test_stores_errors_list(self) -> None:
+        """ConfigValidationError stores list of validation errors."""
+        # Arrange
+        errors = [
+            ValidationError(field="field1", message="error1"),
+            ValidationError(field="field2", message="error2"),
+        ]
+
+        # Act
+        error = ConfigValidationError("Multiple errors", errors=errors)
+
+        # Assert
+        assert error.errors == errors
+        assert len(error.errors) == 2
+
+    def test_errors_defaults_to_empty_list(self) -> None:
+        """ConfigValidationError errors defaults to empty list."""
+        # Arrange & Act
+        error = ConfigValidationError("test")
+
+        # Assert
+        assert error.errors == []
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_valid_config(self, sample_config: Path) -> None:
+        """load_config loads valid config.toml successfully."""
+        # Arrange & Act
+        config = load_config(sample_config)
+
+        # Assert
+        assert isinstance(config, AppConfig)
+        assert config.minecraft_version == "1.21.4"
+        assert config.loader == Loader.FABRIC
+
+    def test_load_config_returns_app_config(self, sample_config: Path) -> None:
+        """load_config returns AppConfig instance."""
+        # Arrange & Act
+        config = load_config(sample_config)
+
+        # Assert
+        assert isinstance(config, AppConfig)
+
+    def test_load_config_file_not_found(self, tmp_path: Path) -> None:
+        """load_config raises FileNotFoundError for missing file."""
+        # Arrange
+        nonexistent = tmp_path / "nonexistent.toml"
+
+        # Act & Assert
+        with pytest.raises(FileNotFoundError):
+            load_config(nonexistent)
+
+    def test_load_config_invalid_toml(self, tmp_path: Path) -> None:
+        """load_config raises ConfigValidationError for invalid TOML."""
+        # Arrange
+        invalid_toml = tmp_path / "invalid.toml"
+        invalid_toml.write_text("this is not valid TOML {{{")
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_config(invalid_toml)
+
+    def test_load_config_missing_required_fields(self, tmp_path: Path) -> None:
+        """load_config raises ConfigValidationError for missing fields."""
+        # Arrange
+        incomplete = tmp_path / "incomplete.toml"
+        incomplete.write_text("[minecraft]\nversion = '1.21.4'\n")
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_config(incomplete)
+
+    def test_load_config_invalid_loader(self, tmp_path: Path) -> None:
+        """load_config raises ConfigValidationError for invalid loader."""
+        # Arrange
+        invalid_loader = tmp_path / "invalid_loader.toml"
+        invalid_loader.write_text(
+            """
+[minecraft]
+version = "1.21.4"
+loader = "invalid_loader"
+
+[paths]
+minecraft_dir = "~/.minecraft"
+"""
+        )
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_config(invalid_loader)
+
+    def test_load_config_with_download_section(self, tmp_path: Path) -> None:
+        """load_config reads download section correctly."""
+        # Arrange
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            """
+[minecraft]
+version = "1.21.4"
+loader = "fabric"
+
+[paths]
+minecraft_dir = "~/.minecraft"
+
+[download]
+max_concurrent = 10
+verify_hash = false
+"""
+        )
+
+        # Act
+        config = load_config(config_file)
+
+        # Assert
+        assert config.max_concurrent_downloads == 10
+        assert config.verify_hash is False
+
+    def test_load_config_expands_paths(self, tmp_path: Path) -> None:
+        """load_config expands ~ in paths."""
+        # Arrange
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            """
+[minecraft]
+version = "1.21.4"
+loader = "fabric"
+
+[paths]
+minecraft_dir = "~/test_minecraft"
+"""
+        )
+
+        # Act
+        config = load_config(config_file)
+
+        # Assert
+        assert config.minecraft_dir.is_absolute()
+        assert "~" not in str(config.minecraft_dir)
+
+
+class TestGenerateConfig:
+    """Tests for generate_config function."""
+
+    def test_generate_config_creates_file(self, tmp_path: Path) -> None:
+        """generate_config creates config.toml."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+
+        # Act
+        generate_config(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=Path("~/.minecraft"),
+            path=config_path,
+        )
+
+        # Assert
+        assert config_path.exists()
+
+    def test_generate_config_returns_path(self, tmp_path: Path) -> None:
+        """generate_config returns path to created file."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+
+        # Act
+        result = generate_config(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=Path("~/.minecraft"),
+            path=config_path,
+        )
+
+        # Assert
+        assert result == config_path
+
+    def test_generate_config_content_structure(self, tmp_path: Path) -> None:
+        """generate_config creates valid TOML structure."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+
+        # Act
+        generate_config(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=Path("~/.minecraft"),
+            path=config_path,
+        )
+
+        # Assert
+        content = config_path.read_text()
+        assert "[minecraft]" in content
+        assert "[paths]" in content
+        assert "[download]" in content
+
+    def test_generate_config_file_exists_raises_error(self, tmp_path: Path) -> None:
+        """generate_config raises FileExistsError if file exists."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("existing content")
+
+        # Act & Assert
+        with pytest.raises(FileExistsError):
+            generate_config(
+                minecraft_version="1.21.4",
+                loader=Loader.FABRIC,
+                minecraft_dir=Path("~/.minecraft"),
+                path=config_path,
+            )
+
+    def test_generate_config_force_overwrites(self, tmp_path: Path) -> None:
+        """generate_config with force=True overwrites existing file."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("existing content")
+
+        # Act
+        generate_config(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=Path("~/.minecraft"),
+            path=config_path,
+            force=True,
+        )
+
+        # Assert
+        content = config_path.read_text()
+        assert "existing content" not in content
+        assert "[minecraft]" in content
+
+    def test_generate_config_all_loaders(self, tmp_path: Path) -> None:
+        """generate_config accepts all Loader types."""
+        # Arrange & Act
+        for loader in Loader:
+            config_path = tmp_path / f"config_{loader.value}.toml"
+            generate_config(
+                minecraft_version="1.21.4",
+                loader=loader,
+                minecraft_dir=Path("~/.minecraft"),
+                path=config_path,
+            )
+
+            # Assert
+            assert config_path.exists()
+            content = config_path.read_text()
+            assert f'loader = "{loader.value}"' in content
+
+    def test_generate_config_roundtrip(self, tmp_path: Path) -> None:
+        """Generated config can be loaded back."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+        minecraft_dir = tmp_path / "minecraft"
+        minecraft_dir.mkdir()
+
+        # Act
+        generate_config(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=minecraft_dir,
+            path=config_path,
+        )
+        loaded = load_config(config_path)
+
+        # Assert
+        assert loaded.minecraft_version == "1.21.4"
+        assert loaded.loader == Loader.FABRIC
+        assert loaded.minecraft_dir == minecraft_dir.resolve()
+
+
+class TestLoadProjects:
+    """Tests for load_projects function."""
+
+    def test_load_valid_projects(self, sample_projects: Path) -> None:
+        """load_projects loads valid projects.toml successfully."""
+        # Arrange & Act
+        projects = load_projects(sample_projects)
+
+        # Assert
+        assert len(projects) == 3
+        assert projects[0].slug == "fabric-api"
+        assert projects[1].slug == "sodium"
+        assert projects[2].slug == "complementary-unbound"
+
+    def test_load_projects_returns_list(self, sample_projects: Path) -> None:
+        """load_projects returns list of ProjectConfig."""
+        # Arrange & Act
+        projects = load_projects(sample_projects)
+
+        # Assert
+        assert isinstance(projects, list)
+        assert all(isinstance(p, ProjectConfig) for p in projects)
+
+    def test_load_projects_file_not_found(self, tmp_path: Path) -> None:
+        """load_projects raises FileNotFoundError for missing file."""
+        # Arrange
+        nonexistent = tmp_path / "nonexistent.toml"
+
+        # Act & Assert
+        with pytest.raises(FileNotFoundError):
+            load_projects(nonexistent)
+
+    def test_load_projects_empty_file(self, tmp_path: Path) -> None:
+        """load_projects returns empty list for empty projects."""
+        # Arrange
+        empty_file = tmp_path / "empty.toml"
+        empty_file.write_text("")
+
+        # Act
+        projects = load_projects(empty_file)
+
+        # Assert
+        assert projects == []
+
+    def test_load_projects_with_version(self, tmp_path: Path) -> None:
+        """load_projects parses version field."""
+        # Arrange
+        projects_file = tmp_path / "projects.toml"
+        projects_file.write_text(
+            """
+[[projects]]
+slug = "fabric-api"
+version = "0.100.0"
+"""
+        )
+
+        # Act
+        projects = load_projects(projects_file)
+
+        # Assert
+        assert len(projects) == 1
+        assert projects[0].version == "0.100.0"
+
+    def test_load_projects_with_channel(self, tmp_path: Path) -> None:
+        """load_projects parses channel field."""
+        # Arrange
+        projects_file = tmp_path / "projects.toml"
+        projects_file.write_text(
+            """
+[[projects]]
+slug = "sodium"
+channel = "beta"
+"""
+        )
+
+        # Act
+        projects = load_projects(projects_file)
+
+        # Assert
+        assert len(projects) == 1
+        assert projects[0].channel == ReleaseChannel.BETA
+
+    def test_load_projects_default_channel(self, tmp_path: Path) -> None:
+        """load_projects uses release as default channel."""
+        # Arrange
+        projects_file = tmp_path / "projects.toml"
+        projects_file.write_text(
+            """
+[[projects]]
+slug = "fabric-api"
+"""
+        )
+
+        # Act
+        projects = load_projects(projects_file)
+
+        # Assert
+        assert len(projects) == 1
+        assert projects[0].channel == ReleaseChannel.RELEASE
+
+    def test_load_projects_invalid_toml(self, tmp_path: Path) -> None:
+        """load_projects raises ConfigValidationError for invalid TOML."""
+        # Arrange
+        invalid_toml = tmp_path / "invalid.toml"
+        invalid_toml.write_text("this is not valid TOML {{{")
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_projects(invalid_toml)
+
+    def test_load_projects_missing_slug(self, tmp_path: Path) -> None:
+        """load_projects raises ConfigValidationError for missing slug."""
+        # Arrange
+        projects_file = tmp_path / "projects.toml"
+        projects_file.write_text(
+            """
+[[projects]]
+version = "0.100.0"
+"""
+        )
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_projects(projects_file)
+
+    def test_load_projects_invalid_channel(self, tmp_path: Path) -> None:
+        """load_projects raises ConfigValidationError for invalid channel."""
+        # Arrange
+        projects_file = tmp_path / "projects.toml"
+        projects_file.write_text(
+            """
+[[projects]]
+slug = "fabric-api"
+channel = "invalid_channel"
+"""
+        )
+
+        # Act & Assert
+        with pytest.raises(ConfigValidationError):
+            load_projects(projects_file)
+
+
+class TestGenerateProjects:
+    """Tests for generate_projects function."""
+
+    def test_generate_projects_creates_file(self, tmp_path: Path) -> None:
+        """generate_projects creates projects.toml."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+
+        # Act
+        generate_projects(path=projects_path)
+
+        # Assert
+        assert projects_path.exists()
+
+    def test_generate_projects_returns_path(self, tmp_path: Path) -> None:
+        """generate_projects returns path to created file."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+
+        # Act
+        result = generate_projects(path=projects_path)
+
+        # Assert
+        assert result == projects_path
+
+    def test_generate_projects_empty_content(self, tmp_path: Path) -> None:
+        """generate_projects creates file with comments."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+
+        # Act
+        generate_projects(path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        # Should have comments but no actual projects
+        assert "#" in content or content.strip() == ""
+
+    def test_generate_projects_file_exists_raises_error(self, tmp_path: Path) -> None:
+        """generate_projects raises FileExistsError if file exists."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects_path.write_text("existing content")
+
+        # Act & Assert
+        with pytest.raises(FileExistsError):
+            generate_projects(path=projects_path)
+
+    def test_generate_projects_force_overwrites(self, tmp_path: Path) -> None:
+        """generate_projects with force=True overwrites existing file."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects_path.write_text("existing content")
+
+        # Act
+        generate_projects(path=projects_path, force=True)
+
+        # Assert
+        content = projects_path.read_text()
+        assert "existing content" not in content
+
+
+class TestSaveProjects:
+    """Tests for save_projects function."""
+
+    def test_save_projects_creates_file(self, tmp_path: Path) -> None:
+        """save_projects creates projects.toml."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [ProjectConfig(slug="fabric-api")]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        assert projects_path.exists()
+
+    def test_save_projects_returns_path(self, tmp_path: Path) -> None:
+        """save_projects returns path to created file."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [ProjectConfig(slug="fabric-api")]
+
+        # Act
+        result = save_projects(projects, path=projects_path)
+
+        # Assert
+        assert result == projects_path
+
+    def test_save_projects_content_structure(self, tmp_path: Path) -> None:
+        """save_projects creates valid TOML structure."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [
+            ProjectConfig(slug="fabric-api"),
+            ProjectConfig(slug="sodium"),
+        ]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        assert "[[projects]]" in content
+        assert 'slug = "fabric-api"' in content
+        assert 'slug = "sodium"' in content
+
+    def test_save_projects_empty_list(self, tmp_path: Path) -> None:
+        """save_projects handles empty list."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects: list[ProjectConfig] = []
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        assert projects_path.exists()
+        loaded = load_projects(projects_path)
+        assert loaded == []
+
+    def test_save_projects_with_version(self, tmp_path: Path) -> None:
+        """save_projects includes version when specified."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [ProjectConfig(slug="fabric-api", version="0.100.0")]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        assert 'version = "0.100.0"' in content
+
+    def test_save_projects_with_channel(self, tmp_path: Path) -> None:
+        """save_projects includes channel when not release."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [ProjectConfig(slug="sodium", channel=ReleaseChannel.BETA)]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        assert 'channel = "beta"' in content
+
+    def test_save_projects_omits_default_channel(self, tmp_path: Path) -> None:
+        """save_projects omits channel when release (default)."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects = [ProjectConfig(slug="fabric-api", channel=ReleaseChannel.RELEASE)]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        assert "channel" not in content
+
+    def test_save_projects_roundtrip(self, tmp_path: Path) -> None:
+        """Saved projects can be loaded back."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        original = [
+            ProjectConfig(slug="fabric-api"),
+            ProjectConfig(slug="sodium", version="0.6.0"),
+            ProjectConfig(slug="some-mod", channel=ReleaseChannel.BETA),
+        ]
+
+        # Act
+        save_projects(original, path=projects_path)
+        loaded = load_projects(projects_path)
+
+        # Assert
+        assert len(loaded) == 3
+        assert loaded[0].slug == "fabric-api"
+        assert loaded[1].slug == "sodium"
+        assert loaded[1].version == "0.6.0"
+        assert loaded[2].slug == "some-mod"
+        assert loaded[2].channel == ReleaseChannel.BETA
+
+    def test_save_projects_overwrites_existing(self, tmp_path: Path) -> None:
+        """save_projects overwrites existing file."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects_path.write_text("old content")
+        projects = [ProjectConfig(slug="new-project")]
+
+        # Act
+        save_projects(projects, path=projects_path)
+
+        # Assert
+        content = projects_path.read_text()
+        assert "old content" not in content
+        assert 'slug = "new-project"' in content
+
+
+class TestValidateConfig:
+    """Tests for validate_config function."""
+
+    def test_valid_config_returns_empty_list(self, tmp_path: Path) -> None:
+        """validate_config returns empty list for valid config."""
+        # Arrange
+        minecraft_dir = tmp_path / "minecraft"
+        minecraft_dir.mkdir()
+        config = AppConfig(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=minecraft_dir,
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert errors == []
+
+    def test_invalid_minecraft_version_format(self) -> None:
+        """validate_config detects invalid minecraft_version format."""
+        # Arrange
+        config = AppConfig(
+            minecraft_version="invalid",
+            loader=Loader.FABRIC,
+            minecraft_dir=Path("/tmp"),
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert len(errors) > 0
+        assert any(e.field == "minecraft_version" for e in errors)
+
+    def test_valid_minecraft_version_formats(self, tmp_path: Path) -> None:
+        """validate_config accepts valid version formats."""
+        # Arrange
+        minecraft_dir = tmp_path / "minecraft"
+        minecraft_dir.mkdir()
+        valid_versions = ["1.21.4", "1.21", "1.21.4-pre1", "1.20.1"]
+
+        # Act & Assert
+        for version in valid_versions:
+            config = AppConfig(
+                minecraft_version=version,
+                loader=Loader.FABRIC,
+                minecraft_dir=minecraft_dir,
+            )
+            errors = validate_config(config)
+            version_errors = [e for e in errors if e.field == "minecraft_version"]
+            assert len(version_errors) == 0, f"Version {version} should be valid"
+
+    def test_minecraft_dir_not_exists(self, tmp_path: Path) -> None:
+        """validate_config detects non-existent minecraft_dir."""
+        # Arrange
+        nonexistent_dir = tmp_path / "nonexistent"
+        config = AppConfig(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=nonexistent_dir,
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert len(errors) > 0
+        assert any(e.field == "minecraft_dir" for e in errors)
+
+    def test_minecraft_dir_exists(self, tmp_path: Path) -> None:
+        """validate_config passes for existing minecraft_dir."""
+        # Arrange
+        minecraft_dir = tmp_path / "minecraft"
+        minecraft_dir.mkdir()
+        config = AppConfig(
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            minecraft_dir=minecraft_dir,
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        dir_errors = [e for e in errors if e.field == "minecraft_dir"]
+        assert len(dir_errors) == 0
+
+    def test_multiple_errors(self, tmp_path: Path) -> None:
+        """validate_config returns all errors."""
+        # Arrange
+        config = AppConfig(
+            minecraft_version="invalid",
+            loader=Loader.FABRIC,
+            minecraft_dir=tmp_path / "nonexistent",
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert len(errors) == 2
+        fields = {e.field for e in errors}
+        assert "minecraft_version" in fields
+        assert "minecraft_dir" in fields
+
+    def test_error_includes_field_name(self, tmp_path: Path) -> None:
+        """ValidationError includes field name."""
+        # Arrange
+        config = AppConfig(
+            minecraft_version="invalid",
+            loader=Loader.FABRIC,
+            minecraft_dir=tmp_path,
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert len(errors) > 0
+        assert all(isinstance(e.field, str) for e in errors)
+        assert all(e.field != "" for e in errors)
+
+    def test_error_includes_message(self, tmp_path: Path) -> None:
+        """ValidationError includes descriptive message."""
+        # Arrange
+        config = AppConfig(
+            minecraft_version="invalid",
+            loader=Loader.FABRIC,
+            minecraft_dir=tmp_path,
+        )
+
+        # Act
+        errors = validate_config(config)
+
+        # Assert
+        assert len(errors) > 0
+        assert all(isinstance(e.message, str) for e in errors)
+        assert all(e.message != "" for e in errors)


### PR DESCRIPTION
## 概要

設定ファイル（config.toml / projects.toml）の読み書き・検証機能を実装しました。
Phase 1 Core実装の一環として、設定管理機能（F-101〜F-107）を完成させました。

## 関連 Issue

<!-- 該当する Issue 番号があれば記載してください -->

Closes #2 

## 変更種別

- [x] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

### 新規追加モジュール

**`src/mcpax/core/config.py`** (274行)

以下の機能を実装：

- `load_config()`: config.toml の読み込み・パース
- `generate_config()`: config.toml の新規生成
- `validate_config()`: 設定値のバリデーション
- `load_projects()`: projects.toml の読み込み・パース
- `save_projects()`: projects.toml への保存
- `generate_projects()`: 空の projects.toml の生成
- `resolve_path()`: パス解決（チルダ展開、絶対パス変換）

### バリデーション機能

- Minecraftバージョン形式チェック（正規表現: `^\d+\.\d+(\.\d+)?(-\w+)?$`）
- minecraft_dir の存在確認
- `ConfigValidationError` カスタム例外による詳細なエラー情報提供

### 技術選定

- **読み込み**: `tomllib` (Python 3.11+ 標準ライブラリ)
- **書き込み**: `tomlkit` (フォーマット・コメント保持)
- **型安全性**: Pydantic モデル (`AppConfig`, `ProjectConfig`) との統合

### その他の変更

- `pyproject.toml`: `tomlkit>=0.12` 依存関係追加
- `README.md`: 開発状況セクション追加
- `docs/10_summary.md`: 技術スタック更新（TOML処理、バリデーション）

## テスト

### テスト実行結果

```bash
uv run pytest tests/unit/test_config.py -v
# ========================== 55 passed ==========================
```

### テストカバレッジ

tests/unit/test_config.py (843行、55テスト)

- ✅ resolve_path: 6テスト（チルダ展開、相対パス、絶対パス）
- ✅ load_config: 8テスト（正常系、TOML構文エラー、必須項目欠落、不正な値）
- ✅ generate_config: 8テスト（生成、上書き、ラウンドトリップ）
- ✅ load_projects: 7テスト（空ファイル、version/channel パース）
- ✅ generate_projects: 5テスト（生成、上書き）
- ✅ save_projects: 10テスト（保存、デフォルト値省略、ラウンドトリップ）
- ✅ validate_config: 11テスト（バージョン形式、ディレクトリ存在確認、複数エラー）

全てのテストでAAA（Arrange-Act-Assert）パターンを適用しています。

## チェックリスト

- [x] コードが ../CONTRIBUTING.md のガイドラインに従っている
- [x] uv run ruff format src tests でフォーマット済み
- [x] uv run ruff check src tests がエラーなしで通る
- [x] uv run ty check src がエラーなしで通る
- [x] uv run pytest が全てパス
- [x] 新機能の場合、テストを追加した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

## 補足情報（任意）

### 使用例

```python

from mcpax.core.config import load_config, generate_config
from mcpax.core.models import Loader
from pathlib import Path

# 設定ファイル生成
generate_config(
    minecraft_version="1.21.4",
    loader=Loader.FABRIC,
    minecraft_dir=Path("~/.minecraft")
)

# 読み込みと検証
config = load_config()
errors = validate_config(config)
if errors:
    for error in errors:
        print(f"{error.field}: {error.message}")

```

### 次のステップ（Phase 1 残タスク）

- api.py: Modrinth API クライアント実装
- downloader.py: ダウンロード・SHA512ハッシュ検証
- manager.py: 全体オーケストレーション
