### PR TITLE
fix: issue #23 use version id in updates

### DIFF
--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -398,6 +398,7 @@ class ProjectManager:
                         current_version=None,
                         current_file=None,
                         latest_version=None,
+                        latest_version_id=None,
                         latest_file=None,
                         error=str(e),
                     )
@@ -429,6 +430,7 @@ class ProjectManager:
                 current_version=installed.version_number if installed else None,
                 current_file=installed,
                 latest_version=None,
+                latest_version_id=None,
                 latest_file=None,
             )
 
@@ -450,6 +452,7 @@ class ProjectManager:
             current_version=installed.version_number if installed else None,
             current_file=installed,
             latest_version=latest.version_number,
+            latest_version_id=latest.id,
             latest_file=primary_file,
         )
 
@@ -528,6 +531,10 @@ class ProjectManager:
                 update, project_type = update_info[slug]
 
                 try:
+                    if update.latest_version_id is None:
+                        result.failed.append((slug, "Latest version id is None"))
+                        continue
+
                     # Backup existing file if needed
                     if (
                         backup
@@ -559,7 +566,7 @@ class ProjectManager:
                         slug=slug,
                         project_type=project_type,
                         filename=final_path.name,
-                        version_id=update.latest_file.hashes.get("sha512", "")[:12],
+                        version_id=update.latest_version_id,
                         version_number=update.latest_version or "unknown",
                         sha512=update.latest_file.hashes.get("sha512", ""),
                         installed_at=datetime.now(UTC),

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -168,6 +168,7 @@ class UpdateCheckResult(BaseModel):
     current_version: str | None
     current_file: InstalledFile | None
     latest_version: str | None
+    latest_version_id: str | None = None
     latest_file: ProjectFile | None
     error: str | None = None
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -441,6 +441,7 @@ class TestUpdateCheckResult:
             current_version="0.5.0",
             current_file=current_file,
             latest_version="0.6.0",
+            latest_version_id="NEW456",
             latest_file=latest_file,
         )
 
@@ -449,6 +450,7 @@ class TestUpdateCheckResult:
         assert result.current_version == "0.5.0"
         assert result.current_file == current_file
         assert result.latest_version == "0.6.0"
+        assert result.latest_version_id == "NEW456"
         assert result.latest_file == latest_file
 
     def test_create_not_installed(self) -> None:
@@ -466,6 +468,7 @@ class TestUpdateCheckResult:
         assert result.status == InstallStatus.NOT_INSTALLED
         assert result.current_version is None
         assert result.current_file is None
+        assert result.latest_version_id is None
 
 
 class TestDownloadTask:


### PR DESCRIPTION
## 概要

UpdateCheckResult に latest_version_id を追加し、更新適用時の version_id をハッシュではなく Modrinth の version id で保存するよう修正しました。

## 関連 Issue

Closes #23

## 変更種別

- [ ] 新機能（feat）
- [x] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

- UpdateCheckResult に latest_version_id を追加
- _check_single_update で version id を保存
- apply_updates で保存する version_id を latest_version_id に変更
- モデルテストを更新

## テスト

- 未実施

## チェックリスト

- [ ] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [ ] `uv run ruff format src tests` でフォーマット済み
- [ ] `uv run ruff check src tests` がエラーなしで通る
- [ ] `uv run ty check src` がエラーなしで通る
- [ ] `uv run pytest` が全てパス
- [ ] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

## 補足情報（任意）
