### PR TITLE
refactor: improve code style and type hints

### DIFF
--- a/src/mcpax/core/api.py
+++ b/src/mcpax/core/api.py
@@ -1,7 +1,9 @@
 """Modrinth API client."""
 
 import asyncio
+import re
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Self
 
 import httpx
@@ -76,7 +78,12 @@ class ModrinthClient:
             )
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Async context manager exit."""
         if self._owns_client and self._client:
             await self._client.aclose()
@@ -121,8 +128,6 @@ class ModrinthClient:
             # Use provided slug or extract from path
             if slug is None:
                 # Try to extract slug from path (e.g., /project/{slug})
-                import re
-
                 match = re.search(r"/project/([^/]+)", str(response.url.path))
                 slug = match.group(1) if match else "unknown"
             raise ProjectNotFoundError(slug)

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -199,9 +199,16 @@ class StateFile(BaseModel):
     files: dict[str, InstalledFile] = Field(default_factory=dict)
 
 
+class FailedUpdate(BaseModel):
+    """Failed update information."""
+
+    slug: str
+    error: str
+
+
 class UpdateResult(BaseModel):
     """Result of applying updates."""
 
     successful: list[str]
-    failed: list[tuple[str, str]]
+    failed: list[FailedUpdate]
     backed_up: list[Path]

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1264,7 +1264,7 @@ class TestApplyUpdates:
 
         # Assert
         assert result.successful == []
-        assert any(slug == "sodium" for slug, _ in result.failed)
+        assert any(f.slug == "sodium" for f in result.failed)
         state = await manager._load_state()
         assert "sodium" not in state.files
 
@@ -1347,7 +1347,7 @@ class TestApplyUpdates:
 
         # Assert
         assert result.successful == ["sodium"]
-        assert any(slug == "lithium" for slug, _ in result.failed)
+        assert any(f.slug == "lithium" for f in result.failed)
         assert (tmp_path / "mods" / latest_file_ok.filename).exists()
         assert not (tmp_path / "mods" / latest_file_fail.filename).exists()
 
@@ -1423,7 +1423,7 @@ class TestApplyUpdatesRollback:
         # Assert
         assert old_file.exists()
         assert not (tmp_path / "mods" / latest_file.filename).exists()
-        assert any(slug == "sodium" for slug, _ in result.failed)
+        assert any(f.slug == "sodium" for f in result.failed)
 
     async def test_new_file_placed_before_old_file_deleted(
         self,
@@ -1572,7 +1572,7 @@ class TestApplyUpdatesRollback:
         # Assert
         assert old_file.exists()
         assert not expected_new_path.exists()
-        assert any(slug == "sodium" for slug, _ in result.failed)
+        assert any(f.slug == "sodium" for f in result.failed)
 
     def test_returns_false_when_latest_is_none(self, tmp_path: Path) -> None:
         """Returns False when latest is None."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,6 +9,7 @@ from mcpax.core.models import (
     DependencyType,
     DownloadResult,
     DownloadTask,
+    FailedUpdate,
     InstalledFile,
     InstallStatus,
     Loader,
@@ -505,19 +506,36 @@ class TestStateFile:
         assert state.files["sodium"] == installed
 
 
+class TestFailedUpdate:
+    """Tests for FailedUpdate model."""
+
+    def test_create_with_all_fields(self) -> None:
+        """FailedUpdate can be created with all fields."""
+        failed = FailedUpdate(
+            slug="sodium",
+            error="Download failed: Network timeout",
+        )
+
+        assert failed.slug == "sodium"
+        assert failed.error == "Download failed: Network timeout"
+
+
 class TestUpdateResult:
     """Tests for UpdateResult model."""
 
     def test_create_with_results(self) -> None:
         """UpdateResult can be created with success and failure lists."""
+        failed_update = FailedUpdate(slug="iris", error="download failed")
         result = UpdateResult(
             successful=["sodium"],
-            failed=[("iris", "download failed")],
+            failed=[failed_update],
             backed_up=[Path("/tmp/sodium.jar")],
         )
 
         assert result.successful == ["sodium"]
-        assert result.failed == [("iris", "download failed")]
+        assert len(result.failed) == 1
+        assert result.failed[0].slug == "iris"
+        assert result.failed[0].error == "download failed"
         assert result.backed_up == [Path("/tmp/sodium.jar")]
 
 


### PR DESCRIPTION
## 概要

Issue #28 で指摘されたコードスタイルと型ヒントの改善を実施しました。

## 関連 Issue

Closes #28

## 変更種別

- [ ] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [x] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

- `FailedUpdate` モデルを追加し、`UpdateResult.failed` の型を `list[tuple[str, str]]` から `list[FailedUpdate]` に改善
- `api.py` の `import re` をメソッド内からモジュールレベルに移動
- `__aexit__` メソッドの型ヒントを追加（`api.py`, `manager.py`, `downloader.py`）
- `downloader.py` の `self._client` の型ヒントを `httpx.AsyncClient | None = None` に改善
- `manager.py` で `FailedUpdate` モデルを使用するように修正
- テストコードを `FailedUpdate` モデルに対応

## テスト

- `uv run ty check src`: All checks passed!
- `uv run ruff format src tests && uv run ruff check src tests --fix`: All checks passed!
- `uv run pytest`: 222 passed, カバレッジ 92%

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [x] 必要に応じてドキュメントを更新した

## 補足情報

この変更により、より型安全で保守性の高いコードになりました。特に `FailedUpdate` モデルの導入により、失敗情報の扱いが明示的になりました。