### PR TITLE
feat(cli): implement init command with XDG Base Directory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ uv.lock
 
 # Project specific
 .mcpax-state.json
+config.toml
+projects.toml

--- a/README.md
+++ b/README.md
@@ -32,7 +32,24 @@ uv sync
 mcpax init
 ```
 
-### 2. 設定ファイルの作成
+このコマンドで `config.toml` と `projects.toml` が自動生成されます。
+
+#### 設定ファイルの場所
+
+設定ファイルは [XDG Base Directory 仕様](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) に準拠した場所に配置されます：
+
+- **XDG_CONFIG_HOME が設定されている場合**: `$XDG_CONFIG_HOME/mcpax/`
+- **未設定の場合（デフォルト）**: `~/.config/mcpax/`
+
+```bash
+# デフォルトの配置場所
+~/.config/mcpax/config.toml
+~/.config/mcpax/projects.toml
+```
+
+### 2. 設定ファイルの編集
+
+生成された `config.toml` と `projects.toml` を必要に応じて編集します。
 
 `config.toml`:
 

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -1,16 +1,31 @@
 """Typer CLI application."""
 
+from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.console import Console
 
 from mcpax import __version__
+from mcpax.core.config import (
+    generate_config,
+    generate_projects,
+    get_config_dir,
+    get_default_config_path,
+    get_default_projects_path,
+)
+from mcpax.core.models import Loader
 
 app = typer.Typer(
     name="mcpax",
     help="Minecraft MOD/Shader/Resource Pack manager via Modrinth API",
     no_args_is_help=True,
 )
+
+# Constants
+DEFAULT_MINECRAFT_VERSION = "1.21.4"
+DEFAULT_MINECRAFT_DIR = Path("~/.minecraft")
+console = Console()
 
 
 def version_callback(value: bool) -> None:
@@ -34,6 +49,84 @@ def callback(
     ] = None,
 ) -> None:
     """Minecraft MOD/Shader/Resource Pack manager via Modrinth API."""
+
+
+@app.command()
+def init(
+    non_interactive: Annotated[
+        bool,
+        typer.Option(
+            "--non-interactive",
+            "-y",
+            help="Use default values without prompting.",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Overwrite existing configuration files.",
+        ),
+    ] = False,
+) -> None:
+    """Initialize configuration files (config.toml and projects.toml).
+
+    Configuration files are created in XDG Base Directory compliant location:
+    - $XDG_CONFIG_HOME/mcpax/ (if XDG_CONFIG_HOME is set)
+    - ~/.config/mcpax/ (default)
+    """
+    # Get configuration values
+    if non_interactive:
+        minecraft_version = DEFAULT_MINECRAFT_VERSION
+        loader = Loader.FABRIC
+        minecraft_dir = DEFAULT_MINECRAFT_DIR
+    else:
+        minecraft_version = typer.prompt(
+            "Minecraft version", default=DEFAULT_MINECRAFT_VERSION
+        )
+        while True:
+            loader_str = typer.prompt(
+                "Mod loader (fabric/forge/neoforge/quilt)", default="fabric"
+            )
+            try:
+                loader = Loader(loader_str.lower())
+                break
+            except ValueError:
+                console.print(
+                    "[red]無効なローダーです。"
+                    "fabric, forge, neoforge, quilt "
+                    "のいずれかを入力してください。[/red]"
+                )
+        minecraft_dir_str = typer.prompt(
+            "Minecraft directory", default=str(DEFAULT_MINECRAFT_DIR)
+        )
+        minecraft_dir = Path(minecraft_dir_str)
+
+    # Generate config files
+    try:
+        config_path = generate_config(
+            minecraft_version=minecraft_version,
+            loader=loader,
+            minecraft_dir=minecraft_dir,
+            path=get_default_config_path(),
+            force=force,
+        )
+        console.print(f"✓ Created {config_path}", style="green")
+
+        projects_path = generate_projects(path=get_default_projects_path(), force=force)
+        console.print(f"✓ Created {projects_path}", style="green")
+
+        console.print("\n[bold]Initialization complete![/bold]")
+        console.print(f"Configuration stored in: {get_config_dir()}")
+        console.print("Run 'mcpax add <slug>' to add projects.")
+
+    except FileExistsError as e:
+        filename = Path(str(e).split(":", 1)[1].strip()).name
+        console.print(
+            f"[red]Error:[/red] {filename} already exists. Use --force to overwrite."
+        )
+        raise typer.Exit(code=1) from None
 
 
 @app.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,17 @@ from mcpax.core.api import ModrinthClient
 from mcpax.core.models import ProjectVersion, ReleaseChannel
 
 
+@pytest.fixture(autouse=True)
+def fixed_terminal_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fix terminal width for consistent Rich output across different environments.
+
+    This prevents CI/local environment differences in terminal width from causing
+    test failures due to line wrapping in Rich console output.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("LINES", "50")
+
+
 @pytest.fixture
 def fixtures_dir() -> Path:
     """Return the path to the fixtures directory."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,8 @@
 """Unit tests for CLI application."""
 
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
 
 from mcpax import __version__
@@ -64,3 +67,194 @@ class TestHelp:
         # Assert
         assert result.exit_code == 0
         assert "Minecraft MOD/Shader/Resource Pack manager" in result.stdout
+
+
+class TestInitCommand:
+    """Tests for init command."""
+
+    def test_init_non_interactive_creates_config_file(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init -y creates config.toml."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert (tmp_path / "mcpax" / "config.toml").exists()
+
+    def test_init_non_interactive_creates_projects_file(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init -y creates projects.toml."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert (tmp_path / "mcpax" / "projects.toml").exists()
+
+    def test_init_non_interactive_uses_default_values(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init -y uses default values in config.toml."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 0
+        config_content = (tmp_path / "mcpax" / "config.toml").read_text()
+        assert "1.21.4" in config_content
+        assert "fabric" in config_content
+        assert "~/.minecraft" in config_content
+
+    def test_init_short_flag_y(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init with short flag -y works."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert (tmp_path / "mcpax" / "config.toml").exists()
+        assert (tmp_path / "mcpax" / "projects.toml").exists()
+
+    def test_init_fails_when_config_exists(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init fails when config.toml already exists."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "mcpax"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.toml").write_text("")
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "config.toml already exists" in result.stdout
+        assert "Use --force to overwrite" in result.stdout
+
+    def test_init_fails_when_projects_exists(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init fails when projects.toml already exists."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "mcpax"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "projects.toml").write_text("")
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "projects.toml already exists" in result.stdout
+        assert "Use --force to overwrite" in result.stdout
+
+    def test_init_force_overwrites_config(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init --force overwrites existing files."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "mcpax"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.toml").write_text("old content")
+        (config_dir / "projects.toml").write_text("old content")
+
+        # Act
+        result = runner.invoke(app, ["init", "-y", "--force"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "old content" not in (config_dir / "config.toml").read_text()
+        assert "old content" not in (config_dir / "projects.toml").read_text()
+
+    def test_init_force_short_flag_f(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init -f short flag works."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "mcpax"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.toml").write_text("old")
+
+        # Act
+        result = runner.invoke(app, ["init", "-y", "-f"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert (config_dir / "config.toml").exists()
+
+    def test_init_interactive_prompts_for_values(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init prompts for values in interactive mode."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(
+            app, ["init"], input="1.20.1\nforge\n/custom/minecraft\n"
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        config_content = (tmp_path / "mcpax" / "config.toml").read_text()
+        assert "1.20.1" in config_content
+        assert "forge" in config_content
+        assert "/custom/minecraft" in config_content
+
+    def test_init_interactive_uses_defaults_on_empty_input(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init uses defaults when user presses enter."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init"], input="\n\n\n")
+
+        # Assert
+        assert result.exit_code == 0
+        config_content = (tmp_path / "mcpax" / "config.toml").read_text()
+        assert "1.21.4" in config_content
+        assert "fabric" in config_content
+        assert "~/.minecraft" in config_content
+
+    def test_init_shows_success_message(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that init shows success message."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = runner.invoke(app, ["init", "-y"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "Created" in result.stdout
+        assert "config.toml" in result.stdout
+        assert "projects.toml" in result.stdout
+        assert "Initialization complete!" in result.stdout
+        assert "Configuration stored in:" in result.stdout
+        assert "mcpax add" in result.stdout

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,9 @@ from mcpax.core.config import (
     ValidationError,
     generate_config,
     generate_projects,
+    get_config_dir,
+    get_default_config_path,
+    get_default_projects_path,
     load_config,
     load_projects,
     resolve_path,
@@ -16,6 +19,118 @@ from mcpax.core.config import (
     validate_config,
 )
 from mcpax.core.models import AppConfig, Loader, ProjectConfig, ReleaseChannel
+
+
+class TestGetConfigDir:
+    """Tests for get_config_dir function."""
+
+    def test_uses_xdg_config_home_when_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """get_config_dir uses XDG_CONFIG_HOME when set."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = get_config_dir()
+
+        # Assert
+        assert result == tmp_path / "mcpax"
+
+    def test_uses_default_when_xdg_config_home_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_config_dir uses ~/.config/mcpax when XDG_CONFIG_HOME not set."""
+        # Arrange
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        # Act
+        result = get_config_dir()
+
+        # Assert
+        assert result == Path.home() / ".config" / "mcpax"
+
+    def test_uses_default_when_xdg_config_home_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_config_dir uses default when XDG_CONFIG_HOME is empty."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", "")
+
+        # Act
+        result = get_config_dir()
+
+        # Assert
+        assert result == Path.home() / ".config" / "mcpax"
+
+    def test_uses_default_when_xdg_config_home_whitespace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_config_dir uses default when XDG_CONFIG_HOME is whitespace."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", "   ")
+
+        # Act
+        result = get_config_dir()
+
+        # Assert
+        assert result == Path.home() / ".config" / "mcpax"
+
+
+class TestGetDefaultConfigPath:
+    """Tests for get_default_config_path function."""
+
+    def test_returns_config_toml_in_config_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """get_default_config_path returns config.toml in config directory."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = get_default_config_path()
+
+        # Assert
+        assert result == tmp_path / "mcpax" / "config.toml"
+
+    def test_uses_default_config_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_default_config_path uses default config directory."""
+        # Arrange
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        # Act
+        result = get_default_config_path()
+
+        # Assert
+        assert result == Path.home() / ".config" / "mcpax" / "config.toml"
+
+
+class TestGetDefaultProjectsPath:
+    """Tests for get_default_projects_path function."""
+
+    def test_returns_projects_toml_in_config_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """get_default_projects_path returns projects.toml in config directory."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        # Act
+        result = get_default_projects_path()
+
+        # Assert
+        assert result == tmp_path / "mcpax" / "projects.toml"
+
+    def test_uses_default_config_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_default_projects_path uses default config directory."""
+        # Arrange
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        # Act
+        result = get_default_projects_path()
+
+        # Assert
+        assert result == Path.home() / ".config" / "mcpax" / "projects.toml"
 
 
 class TestResolvePath:


### PR DESCRIPTION
## Summary

Issue #6 のinitコマンドを実装しました。また、設定ファイルの配置場所をXDG Base Directory仕様に準拠した `~/.config/mcpax/` にしました。

Closes #6

## Changes

### CLI Implementation - `init` command
- **対話モード**: Minecraftバージョン、Loader、ディレクトリを対話的に入力
- **非対話モード** (`-y`): デフォルト値で自動生成
- **上書きモード** (`--force`): 既存ファイルを上書き
- フルパス表示と設定ディレクトリの場所を表示
- XDG Base Directory仕様に準拠した場所に設定ファイルを作成

### Core Implementation - XDG Base Directory support
- `get_config_dir()`, `get_default_config_path()`, `get_default_projects_path()` 関数を追加
- `XDG_CONFIG_HOME` 環境変数のサポート
- 設定ファイルを `~/.config/mcpax/` に配置（カレントディレクトリではなく）
- `generate_config()` と `generate_projects()` で設定ディレクトリを自動作成

### Documentation
- READMEに設定ファイルの場所についての詳細説明を追加
- XDG Base Directory仕様への準拠を明記
- `init` コマンドのヘルプメッセージにXDG設定場所の説明を追加

### Tests
- パス取得関数のテストを8個追加
- `init` コマンドのテストを11個追加（Issue #6の受け入れ条件をすべて満たす）
- 全テスト241個すべてパス、カバレッジ92%

## Configuration File Locations

設定ファイルは以下の場所に配置されます：
- `$XDG_CONFIG_HOME/mcpax/` (XDG_CONFIG_HOMEが設定されている場合)
- `~/.config/mcpax/` (デフォルト)

## 受け入れ条件（Issue #6）

- ✅ 対話モードで設定を収集できる
- ✅ config.toml が生成される
- ✅ projects.toml が生成される
- ✅ `--non-interactive` でデフォルト値が使用される
- ✅ 既存ファイルがある場合にエラーになる
- ✅ `--force` で上書きできる
- ✅ ユニットテストが実装されている（11個のテスト）

## Test Results

```
✅ 全テスト: 241/241 パス
✅ カバレッジ: 92%
✅ ruff format: OK
✅ ruff check: OK
✅ ty check: OK
✅ CodeRabbit review: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)