### PR TITLE
feat: implement mcpax remove command

### DIFF
--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -286,6 +286,31 @@ class ProjectManager:
                 f"Failed to delete file: {e}", path=file_path
             ) from e
 
+    async def uninstall_project(self, slug: str) -> tuple[bool, str | None]:
+        """Uninstall a project by removing its file and state.
+
+        Args:
+            slug: Project slug to uninstall
+
+        Returns:
+            Tuple of (success, filename) where success is True if file was deleted,
+            False if not installed, and filename is the deleted file name or None.
+
+        Raises:
+            FileOperationError: If file deletion fails
+        """
+        installed = await self.get_installed_file(slug)
+        if installed is None:
+            return (False, None)
+
+        # Delete the file
+        await self.delete_file(installed.file_path)
+
+        # Remove from state
+        await self._remove_installed_file(slug)
+
+        return (True, installed.filename)
+
     # Status Functions (F-405, F-406)
 
     async def get_installed_file(self, slug: str) -> InstalledFile | None:


### PR DESCRIPTION
## Summary
- `mcpax remove <slug>` コマンドを実装
- `--delete-file` / `-d` オプションでインストール済みファイルも削除
- `--yes` / `-y` オプションで確認プロンプトをスキップ
- ProjectManagerと連携してファイル削除と状態管理を実行

## Implementation
- **src/mcpax/cli/app.py**: `remove` コマンドとヘルパー関数 `_remove_installed_file_with_manager` を追加
- **tests/unit/test_cli.py**: 8個の包括的なテストケースを実装

## Test Coverage
| # | テスト名 | 検証内容 |
|---|---------|----------|
| 1 | `test_remove_project_not_found` | 存在しないプロジェクトでエラー |
| 2 | `test_remove_project_success` | 正常削除 |
| 3 | `test_remove_project_confirmation_no` | 確認でNoを選択した場合 |
| 4 | `test_remove_project_skip_confirmation` | --yes で確認スキップ |
| 5 | `test_remove_project_with_delete_file` | --delete-file でファイル削除 |
| 6 | `test_remove_project_delete_file_not_installed` | 未インストール時の処理 |
| 7 | `test_remove_project_no_config` | config.toml なしでエラー |
| 8 | `test_remove_project_combined_flags` | -d -y 同時使用 |

## Quality Checks
- ✅ ruff format
- ✅ ruff check
- ✅ ty check
- ✅ pytest: 全256テストパス（カバレッジ90%）

## Acceptance Criteria
- [x] プロジェクトを管理対象から削除できる
- [x] 確認プロンプトが表示される
- [x] --yes で確認をスキップできる
- [x] --delete-file でインストール済みファイルも削除できる
- [x] 存在しないプロジェクトでエラーになる
- [x] ユニットテストが実装されている

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)