### PR TITLE
feat: implement mcpax install command

### DIFF
--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -21,7 +21,13 @@ from mcpax.core.config import (
 )
 from mcpax.core.exceptions import APIError, ProjectNotFoundError
 from mcpax.core.manager import ProjectManager
-from mcpax.core.models import Loader, ModrinthProject, ProjectConfig, ReleaseChannel
+from mcpax.core.models import (
+    InstallStatus,
+    Loader,
+    ModrinthProject,
+    ProjectConfig,
+    ReleaseChannel,
+)
 
 app = typer.Typer(
     name="mcpax",
@@ -320,6 +326,103 @@ def add(
     console.print(
         f"✓ {project.title} ({project_type_str}) を追加しました", style="green"
     )
+
+
+@app.command()
+def install(
+    slug: Annotated[str | None, typer.Argument(help="Project slug to install")] = None,
+    all_projects: Annotated[
+        bool,
+        typer.Option("--all", help="Install all projects from the list."),
+    ] = False,
+) -> None:
+    """Install projects from the managed list.
+
+    Example:
+        mcpax install sodium
+        mcpax install --all
+    """
+    # Check if config.toml exists
+    config_path = get_default_config_path()
+    if not config_path.exists():
+        console.print(
+            "[red]Error:[/red] config.toml not found. Run 'mcpax init' first."
+        )
+        raise typer.Exit(code=1)
+
+    # Load config
+    try:
+        config = load_config()
+    except FileNotFoundError:
+        console.print(
+            "[red]Error:[/red] config.toml not found. Run 'mcpax init' first."
+        )
+        raise typer.Exit(code=1) from None
+
+    # Load existing projects
+    try:
+        projects = load_projects()
+    except FileNotFoundError:
+        console.print(
+            "[red]Error:[/red] projects.toml not found. Run 'mcpax init' first."
+        )
+        raise typer.Exit(code=1) from None
+
+    # Determine target projects
+    if not all_projects and slug is None:
+        console.print("[red]Error:[/red] Specify a project slug or use --all.")
+        raise typer.Exit(code=1)
+
+    target_projects = projects if all_projects else []
+
+    if slug is not None:
+        # Find the specific project
+        project_config = next((p for p in projects if p.slug == slug), None)
+        if project_config is None:
+            console.print(f"[red]Error:[/red] Project '{slug}' not found in the list.")
+            raise typer.Exit(code=1)
+        target_projects = [project_config]
+
+    if not target_projects:
+        console.print("[yellow]No projects to install.[/yellow]")
+        raise typer.Exit(code=0)
+
+    # Install projects
+    async def _install_projects() -> None:
+        async with ProjectManager(config) as manager:
+            # Check updates
+            updates = await manager.check_updates(target_projects)
+
+            # Filter out compatible versions and show warnings
+            for update in updates:
+                if update.status == InstallStatus.NOT_COMPATIBLE:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] No compatible version found "
+                        f"for '{update.slug}'."
+                    )
+                elif update.status == InstallStatus.INSTALLED:
+                    console.print(
+                        f"[blue]Info:[/blue] '{update.slug}' is already up to date."
+                    )
+
+            # Apply updates
+            result = await manager.apply_updates(updates, backup=True)
+
+            # Show results
+            if result.successful:
+                for slug_success in result.successful:
+                    console.print(
+                        f"✓ '{slug_success}' をインストールしました", style="green"
+                    )
+
+            if result.failed:
+                for failed in result.failed:
+                    console.print(
+                        f"[red]Error:[/red] Failed to install "
+                        f"'{failed.slug}': {failed.error}"
+                    )
+
+    asyncio.run(_install_projects())
 
 
 def main() -> None:


### PR DESCRIPTION
## 概要

`mcpax install` コマンドを実装しました。

## 実装内容

- 単一プロジェクトのインストール機能
- `--all` オプションによる全プロジェクトの一括インストール
- プロジェクトリストに存在しない場合のエラーハンドリング
- TDD形式でのテスト実装（先にテストを書いてから実装）

## 変更ファイル

- `src/mcpax/cli/app.py`: installコマンドの実装を追加
- `tests/unit/test_cli.py`: installコマンドのユニットテストを追加

## テスト

- [x] 単一プロジェクトをインストールできる
- [x] `--all` で全プロジェクトをインストールできる
- [x] プロジェクトリストにない場合、適切なエラーメッセージを表示
- [x] ユニットテストが実装されている

## 備考

実際のダウンロード処理とプログレスバー表示は、`manager.py` の実装完了後に統合する予定です。

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)