### PR TITLE
feat(cli): add list command with filtering and JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ mcpax update
 
 ```bash
 mcpax list
+mcpax list --type mod
+mcpax list --status installed
+mcpax list --json
+mcpax list --no-update
+mcpax list --no-cache
+mcpax list --max-concurrency 5
 ```
 
 ## 開発

--- a/docs/06_ui_definition.md
+++ b/docs/06_ui_definition.md
@@ -181,11 +181,15 @@ mcpax list
 | `--type <type>` | `-t` | 種類でフィルタ（mod/shader/resourcepack） |
 | `--status <status>` | `-s` | 状態でフィルタ（installed/not-installed/outdated） |
 | `--json` | | JSON 形式で出力 |
+| `--no-update` / `--fast` | | 更新確認をスキップ（installed/not-installedのみ） |
+| `--no-cache` | | APIキャッシュを使わない |
+| `--max-concurrency <n>` | | APIリクエストの同時実行数 |
 
 #### 動作
 
 1. `projects.toml` を読み込む
 2. 各プロジェクトのインストール状態を確認
+   - `--no-update` の場合は更新確認をスキップ
 3. 一覧を表示
 
 #### 出力例

--- a/docs/07_function_definition.md
+++ b/docs/07_function_definition.md
@@ -648,6 +648,7 @@ class UpdateCheckResult:
     current_version: str | None
     latest_version: str | None
     latest_file: ProjectFile | None
+    error: str | None
 ```
 
 ---

--- a/docs/10_summary.md
+++ b/docs/10_summary.md
@@ -78,7 +78,7 @@
 | mcpax init | 初期セットアップ | --non-interactive |
 | mcpax add \<slug\> | プロジェクト追加 | --version, --channel |
 | mcpax remove \<slug\> | プロジェクト削除 | --delete-file, --yes |
-| mcpax list | 一覧表示 | --type, --status, --json |
+| mcpax list | 一覧表示 | --type, --status, --json, --no-update, --no-cache, --max-concurrency |
 | mcpax search \<query\> | 検索 | --type, --limit |
 | mcpax update | 更新確認・適用 | --check, --yes |
 | mcpax install | インストール | --all |

--- a/docs/11_architecture.md
+++ b/docs/11_architecture.md
@@ -548,11 +548,13 @@ class ProjectManager:
     async def check_updates(
         self,
         projects: list[ProjectConfig],
+        max_concurrency: int = 10,
     ) -> list[UpdateCheckResult]:
         """各プロジェクトの更新有無を確認
 
         Args:
             projects: プロジェクト設定リスト
+            max_concurrency: 最大同時APIリクエスト数
 
         Returns:
             更新確認結果のリスト

--- a/src/mcpax/core/cache.py
+++ b/src/mcpax/core/cache.py
@@ -1,0 +1,78 @@
+"""Simple on-disk cache for Modrinth API responses."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import cast
+
+
+class ApiCache:
+    """Tiny TTL cache backed by a JSON file."""
+
+    def __init__(self, path: Path, ttl_seconds: int = 300) -> None:
+        self._path = path
+        self._ttl_seconds = ttl_seconds
+        self._data: dict[str, dict[str, dict[str, object]]] = {
+            "project": {},
+            "versions": {},
+        }
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return
+        if isinstance(data, dict):
+            self._data["project"] = data.get("project", {}) or {}
+            self._data["versions"] = data.get("versions", {}) or {}
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(self._data))
+        except OSError:
+            return
+
+    def _is_fresh(self, ts: float) -> bool:
+        return (time.time() - ts) <= self._ttl_seconds
+
+    def get_project(self, slug: str) -> dict | None:
+        entry = self._data["project"].get(slug)
+        if not isinstance(entry, dict):
+            return None
+        ts = entry.get("ts")
+        data = entry.get("data")
+        if (
+            isinstance(ts, (int, float))
+            and isinstance(data, dict)
+            and self._is_fresh(ts)
+        ):
+            return data
+        return None
+
+    def set_project(self, slug: str, data: dict) -> None:
+        self._data["project"][slug] = {"ts": time.time(), "data": data}
+        self._save()
+
+    def get_versions(self, slug: str) -> list[dict] | None:
+        entry = self._data["versions"].get(slug)
+        if not isinstance(entry, dict):
+            return None
+        ts = entry.get("ts")
+        data = entry.get("data")
+        if (
+            isinstance(ts, (int, float))
+            and isinstance(data, list)
+            and self._is_fresh(ts)
+        ):
+            return cast(list[dict], data)
+        return None
+
+    def set_versions(self, slug: str, data: list[dict]) -> None:
+        self._data["versions"][slug] = {"ts": time.time(), "data": data}
+        self._save()


### PR DESCRIPTION
## 概要

`mcpax list` コマンドを実装しました。管理対象のプロジェクト一覧をインストール状態と共に表示できます。

## 主な機能

- プロジェクト一覧の表示（種類別にグループ化）
- インストール状態の表示（✓ installed / ○ not-installed / ⚠ outdated / ✗ incompatible）
- `--type` オプションで種類フィルタ（mod/shader/resourcepack）
- `--status` オプションで状態フィルタ（installed/not-installed/outdated）
- `--json` オプションでJSON形式出力

## 使用例

```bash
# 全プロジェクト一覧
mcpax list

# mod のみ表示
mcpax list --type mod

# インストール済みのみ表示
mcpax list --status installed

# JSON 形式で出力
mcpax list --json
```

## テスト

- ユニットテストを追加済み

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)