### PR TITLE
feat(cli): enhance search command with type filtering and JSON output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Automate the manual update process when managing approximately 30 Minecraft proj
 - Define managed projects in TOML configuration files
 - Automatically fetch compatible versions via Modrinth API
 - Secure downloads with SHA512 hash verification
-- Automatic placement based on project type (mod/shader/resourcepack)
+- Automatic placement based on project type (mod/modpack/shader/resourcepack)
 
 ## Tech Stack
 
@@ -160,14 +160,17 @@ slug = "complementary-unbound"  # shader
 ## CLI Command Structure
 
 ```bash
-mcpax init                    # Initialize configuration files
-mcpax add <slug>              # Add project
-mcpax remove <slug>           # Remove project
-mcpax list                    # List registered projects
-mcpax search <query>          # Search Modrinth (separate command)
-mcpax install [--all]         # Install projects
-mcpax update [--check]        # Check/apply updates
-mcpax status                  # Show installation status
+mcpax init                              # Initialize configuration files
+mcpax add <slug>                        # Add project
+mcpax remove <slug>                     # Remove project
+mcpax list [--type TYPE] [--json]       # List registered projects
+mcpax search <query> [OPTIONS]          # Search Modrinth
+  --type/-t TYPE                        #   Filter by type (mod/modpack/shader/resourcepack)
+  --limit/-l N                          #   Number of results (default: 10)
+  --json                                #   Output in JSON format
+mcpax install [--all]                   # Install projects
+mcpax update [--check]                  # Check/apply updates
+mcpax status                            # Show installation status
 ```
 
 ## Testing Strategy
@@ -219,6 +222,7 @@ Determined by `project_type` field in API response:
 - `mod` → `mods/` directory
 - `shader` → `shaderpacks/` directory
 - `resourcepack` → `resourcepacks/` directory
+- `modpack` → Not currently supported for installation (search only)
 
 ### Filename Handling
 - Use `filename` from API response for downloaded files

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # mcpax
 
-Minecraft の MOD / Shader / Resource Pack を Modrinth API 経由で管理する CLI ツール。
+Minecraft の MOD / Modpack / Shader / Resource Pack を Modrinth API 経由で管理する CLI ツール。
 
 ## 特徴
 
 - TOML 形式の設定ファイルでプロジェクトリストを管理
 - 指定した Minecraft バージョン・Loader に対応するプロジェクトを自動取得
 - プロジェクト種別（MOD / Shader / Resource Pack）に応じた適切なディレクトリ配置
+- Modpack の検索機能（インストールは未対応）
 - ハッシュ検証による安全なダウンロード
 - 差分更新（変更があったプロジェクトのみダウンロード）
 
@@ -83,6 +84,9 @@ mcpax add sodium
 
 # slug がわからない場合は検索
 mcpax search shader
+mcpax search sodium --type mod --limit 5
+mcpax search "optimization pack" --type modpack
+mcpax search iris --json
 ```
 
 ### 4. プロジェクトのインストール

--- a/src/mcpax/core/api.py
+++ b/src/mcpax/core/api.py
@@ -259,6 +259,7 @@ class ModrinthClient:
         query: str,
         limit: int = 10,
         offset: int = 0,
+        facets: str | None = None,
     ) -> SearchResult:
         """Search for projects.
 
@@ -266,6 +267,7 @@ class ModrinthClient:
             query: Search query string
             limit: Maximum results (default 10, max 100)
             offset: Pagination offset
+            facets: Optional facets filter (JSON-encoded string)
 
         Returns:
             SearchResult instance
@@ -278,6 +280,8 @@ class ModrinthClient:
             "limit": str(limit),
             "offset": str(offset),
         }
+        if facets is not None:
+            params["facets"] = facets
         response = await self._request("GET", "/search", params=params)
         return SearchResult.model_validate(response.json())
 

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -20,6 +20,7 @@ class ProjectType(str, Enum):
     """Project types on Modrinth."""
 
     MOD = "mod"
+    MODPACK = "modpack"
     SHADER = "shader"
     RESOURCEPACK = "resourcepack"
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -687,6 +687,23 @@ class TestSearch:
         assert "limit=20" in str(request.url)
         assert "offset=10" in str(request.url)
 
+    async def test_facets_parameter(
+        self,
+        httpx_mock: HTTPXMock,
+        search_response: dict,
+    ) -> None:
+        """search includes facets parameter when provided."""
+        # Arrange
+        httpx_mock.add_response(json=search_response)
+
+        # Act
+        async with ModrinthClient() as client:
+            await client.search("sodium", facets='[["project_type:mod"]]')
+
+        # Assert
+        request = httpx_mock.get_request()
+        assert request.url.params.get("facets") == '[["project_type:mod"]]'
+
 
 # === Version Filtering Tests ===
 


### PR DESCRIPTION
## 概要

mcpax に Modrinth 検索コマンドを追加し、CLI/ドキュメント/テストを整備しました。

## 関連 Issue

Closes #10

## 変更種別

- [x] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [x] テスト（test）
- [ ] その他（chore）

## 変更内容

- `mcpax search` コマンドの追加（type フィルタ/limit/json 出力対応）
- 検索結果の整形表示と JSON 出力
- README/CLAUDE のコマンド一覧を更新
- CLI 検索機能の unit テスト追加

## テスト

- `uv run ruff format src tests`
- `uv run ruff check src tests`
- `uv run ty check src`
- `uv run pytest`

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

<!-- UI の変更がある場合、スクリーンショットを添付してください -->

## 補足情報（任意）

<!-- レビュアーに伝えたい追加情報があれば記載してください -->
