### PR TITLE
fix: shader compatibility check always shows 'not compatible'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ src/mcpax/
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mcpax init
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/docs/05_conceptual_data_model.md
+++ b/docs/05_conceptual_data_model.md
@@ -148,7 +148,7 @@ Modrinth API から取得するファイル情報。
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/docs/07_function_definition.md
+++ b/docs/07_function_definition.md
@@ -94,7 +94,7 @@ config.toml を生成する。
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/docs/08_data_definition.md
+++ b/docs/08_data_definition.md
@@ -73,7 +73,7 @@ class AppConfig:
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/docs/11_architecture.md
+++ b/docs/11_architecture.md
@@ -666,7 +666,7 @@ def search(query: str):
 ```toml
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -99,7 +99,8 @@ def init(
     # Get configuration values
     if non_interactive:
         minecraft_version = DEFAULT_MINECRAFT_VERSION
-        loader = Loader.FABRIC
+        mod_loader = Loader.FABRIC
+        shader_loader: Loader | None = Loader.IRIS
         minecraft_dir = DEFAULT_MINECRAFT_DIR
     else:
         minecraft_version = typer.prompt(
@@ -110,12 +111,28 @@ def init(
                 "Mod loader (fabric/forge/neoforge/quilt)", default="fabric"
             )
             try:
-                loader = Loader(loader_str.lower())
+                mod_loader = Loader(loader_str.lower())
                 break
             except ValueError:
                 console.print(
                     "[red]無効なローダーです。"
                     "fabric, forge, neoforge, quilt "
+                    "のいずれかを入力してください。[/red]"
+                )
+        while True:
+            shader_loader_str = typer.prompt(
+                "Shader loader (iris/optifine/none)", default="iris"
+            )
+            if shader_loader_str.lower() in ("none", ""):
+                shader_loader = None
+                break
+            try:
+                shader_loader = Loader(shader_loader_str.lower())
+                break
+            except ValueError:
+                console.print(
+                    "[red]無効なシェーダーローダーです。"
+                    "iris, optifine, none "
                     "のいずれかを入力してください。[/red]"
                 )
         minecraft_dir_str = typer.prompt(
@@ -127,7 +144,8 @@ def init(
     try:
         config_path = generate_config(
             minecraft_version=minecraft_version,
-            loader=loader,
+            mod_loader=mod_loader,
+            shader_loader=shader_loader,
             minecraft_dir=minecraft_dir,
             path=get_default_config_path(),
             force=force,
@@ -353,6 +371,7 @@ def add(
         slug=slug,
         version=version,
         channel=release_channel,
+        project_type=project.project_type,
     )
 
     # Add to list and save

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -8,12 +8,14 @@ from pydantic import BaseModel, Field
 
 
 class Loader(str, Enum):
-    """Mod loader types."""
+    """Mod and shader loader types."""
 
     FABRIC = "fabric"
     FORGE = "forge"
     NEOFORGE = "neoforge"
     QUILT = "quilt"
+    IRIS = "iris"
+    OPTIFINE = "optifine"
 
 
 class ProjectType(str, Enum):
@@ -59,7 +61,8 @@ class AppConfig(BaseModel):
     """Application configuration from config.toml."""
 
     minecraft_version: str
-    loader: Loader
+    mod_loader: Loader
+    shader_loader: Loader | None = None
     minecraft_dir: Path
     mods_dir: Path | None = None
     shaders_dir: Path | None = None
@@ -74,6 +77,7 @@ class ProjectConfig(BaseModel):
     slug: str
     version: str | None = None
     channel: ReleaseChannel = ReleaseChannel.RELEASE
+    project_type: ProjectType | None = None
 
 
 class InstalledFile(BaseModel):

--- a/tests/fixtures/config.toml
+++ b/tests/fixtures/config.toml
@@ -1,6 +1,6 @@
 [minecraft]
 version = "1.21.4"
-loader = "fabric"
+mod_loader = "fabric"
 
 [paths]
 minecraft_dir = "~/.minecraft"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -849,6 +849,117 @@ class TestFilterShaderResourcepack:
         assert len(result) == 1
         assert result[0].version_number == "1.0"
 
+    def test_filters_shader_by_iris_loader(self) -> None:
+        """Filters shader versions by iris loader when specified."""
+        versions = [
+            _make_version(
+                "1.0",
+                game_versions=["1.21.4"],
+                loaders=["iris"],
+            ),
+            _make_version(
+                "2.0",
+                game_versions=["1.21.4"],
+                loaders=["optifine"],
+            ),
+        ]
+        client = ModrinthClient()
+
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.SHADER,
+            shader_loader=Loader.IRIS,
+        )
+
+        assert len(result) == 1
+        assert result[0].version_number == "1.0"
+
+    def test_filters_shader_by_optifine_loader(self) -> None:
+        """Filters shader versions by optifine loader when specified."""
+        versions = [
+            _make_version(
+                "1.0",
+                game_versions=["1.21.4"],
+                loaders=["iris"],
+            ),
+            _make_version(
+                "2.0",
+                game_versions=["1.21.4"],
+                loaders=["optifine"],
+            ),
+        ]
+        client = ModrinthClient()
+
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.SHADER,
+            shader_loader=Loader.OPTIFINE,
+        )
+
+        assert len(result) == 1
+        assert result[0].version_number == "2.0"
+
+    def test_allows_shader_with_both_loaders(self) -> None:
+        """Allows shader versions that support both iris and optifine."""
+        versions = [
+            _make_version(
+                "1.0",
+                game_versions=["1.21.4"],
+                loaders=["iris", "optifine"],
+            ),
+        ]
+        client = ModrinthClient()
+
+        # Should work with iris
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.SHADER,
+            shader_loader=Loader.IRIS,
+        )
+        assert len(result) == 1
+
+        # Should also work with optifine
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.SHADER,
+            shader_loader=Loader.OPTIFINE,
+        )
+        assert len(result) == 1
+
+    def test_shader_without_loader_spec_allows_all(self) -> None:
+        """Shader without shader_loader specified allows all loaders."""
+        versions = [
+            _make_version(
+                "1.0",
+                game_versions=["1.21.4"],
+                loaders=["iris"],
+            ),
+            _make_version(
+                "2.0",
+                game_versions=["1.21.4"],
+                loaders=["optifine"],
+            ),
+        ]
+        client = ModrinthClient()
+
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.SHADER,
+            shader_loader=None,
+        )
+
+        assert len(result) == 2
+
     def test_allows_resourcepack_with_empty_loaders(self) -> None:
         """Allows versions without loaders listed."""
         versions = [
@@ -864,6 +975,27 @@ class TestFilterShaderResourcepack:
             versions,
             minecraft_version="1.21.4",
             loader=Loader.FABRIC,
+        )
+
+        assert len(result) == 1
+        assert result[0].version_number == "1.0"
+
+    def test_resourcepack_ignores_loaders(self) -> None:
+        """Resource packs ignore loader field completely."""
+        versions = [
+            _make_version(
+                "1.0",
+                game_versions=["1.21.4"],
+                loaders=["optifine"],  # Some resourcepacks have optifine features
+            ),
+        ]
+        client = ModrinthClient()
+
+        result = client.filter_compatible_versions(
+            versions,
+            minecraft_version="1.21.4",
+            loader=Loader.FABRIC,
+            project_type=ProjectType.RESOURCEPACK,
         )
 
         assert len(result) == 1

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -225,7 +225,7 @@ class TestInitCommand:
 
         # Act
         result = runner.invoke(
-            app, ["init"], input="1.20.1\nforge\n/custom/minecraft\n"
+            app, ["init"], input="1.20.1\nforge\noptifine\n/custom/minecraft\n"
         )
 
         # Assert
@@ -233,6 +233,7 @@ class TestInitCommand:
         config_content = (tmp_path / "mcpax" / "config.toml").read_text()
         assert "1.20.1" in config_content
         assert "forge" in config_content
+        assert "optifine" in config_content
         assert "/custom/minecraft" in config_content
 
     def test_init_interactive_uses_defaults_on_empty_input(
@@ -243,7 +244,7 @@ class TestInitCommand:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
         # Act
-        result = runner.invoke(app, ["init"], input="\n\n\n")
+        result = runner.invoke(app, ["init"], input="\n\n\n\n")
 
         # Assert
         assert result.exit_code == 0

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -31,7 +31,7 @@ def _make_config(minecraft_dir: Path) -> AppConfig:
     """Helper to create AppConfig for tests."""
     return AppConfig(
         minecraft_version="1.21.4",
-        loader=Loader.FABRIC,
+        mod_loader=Loader.FABRIC,
         minecraft_dir=minecraft_dir,
     )
 
@@ -77,6 +77,23 @@ def _make_version_payload(
         ],
         "dependencies": [],
         "date_published": "2024-01-15T10:30:00Z",
+    }
+
+
+def _make_project_payload(
+    slug: str,
+    project_type: str = "mod",
+) -> dict[str, object]:
+    """Helper to build Modrinth project payloads."""
+    return {
+        "id": "AANobbMI",
+        "slug": slug,
+        "title": slug.capitalize(),
+        "description": f"A {project_type} project",
+        "project_type": project_type,
+        "downloads": 12345678,
+        "icon_url": f"https://cdn.modrinth.com/data/{slug}/icon.png",
+        "versions": ["v1", "v2", "v3"],
     }
 
 
@@ -247,7 +264,7 @@ class TestGetTargetDirectory:
         custom_mods_dir = tmp_path / "custom_mods"
         config = AppConfig(
             minecraft_version="1.21.4",
-            loader=Loader.FABRIC,
+            mod_loader=Loader.FABRIC,
             minecraft_dir=tmp_path,
             mods_dir=custom_mods_dir,
         )
@@ -1009,6 +1026,10 @@ class TestCheckUpdates:
         await manager_temp._save_state(state)
 
         httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium",
+            json=_make_project_payload("sodium"),
+        )
+        httpx_mock.add_response(
             url="https://api.modrinth.com/v2/project/sodium/version",
             json=[
                 _make_version_payload(
@@ -1052,6 +1073,10 @@ class TestCheckUpdates:
         await manager_temp._save_state(state)
 
         httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium",
+            json=_make_project_payload("sodium"),
+        )
+        httpx_mock.add_response(
             url="https://api.modrinth.com/v2/project/sodium/version",
             json=[
                 _make_version_payload(
@@ -1092,6 +1117,10 @@ class TestCheckUpdates:
         await manager_temp._save_state(state)
 
         httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium",
+            json=_make_project_payload("sodium"),
+        )
+        httpx_mock.add_response(
             url="https://api.modrinth.com/v2/project/sodium/version",
             json=[
                 _make_version_payload(
@@ -1101,6 +1130,10 @@ class TestCheckUpdates:
                     sha512="matchhash" * 20,
                 )
             ],
+        )
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/lithium",
+            json=_make_project_payload("lithium"),
         )
         httpx_mock.add_response(
             url="https://api.modrinth.com/v2/project/lithium/version",
@@ -1136,6 +1169,10 @@ class TestCheckUpdates:
         """Returns CHECK_FAILED when API errors occur."""
         # Arrange
         config = _make_config(tmp_path)
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium",
+            json=_make_project_payload("sodium"),
+        )
         for _ in range(ModrinthClient.DEFAULT_MAX_RETRIES + 1):
             httpx_mock.add_response(
                 url="https://api.modrinth.com/v2/project/sodium/version",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -142,12 +142,12 @@ class TestAppConfig:
 
         config = AppConfig(
             minecraft_version="1.21.4",
-            loader=Loader.FABRIC,
+            mod_loader=Loader.FABRIC,
             minecraft_dir=Path("~/.minecraft"),
         )
 
         assert config.minecraft_version == "1.21.4"
-        assert config.loader == Loader.FABRIC
+        assert config.mod_loader == Loader.FABRIC
         assert config.minecraft_dir == Path("~/.minecraft")
 
     def test_default_values(self) -> None:
@@ -155,7 +155,7 @@ class TestAppConfig:
 
         config = AppConfig(
             minecraft_version="1.21.4",
-            loader=Loader.FABRIC,
+            mod_loader=Loader.FABRIC,
             minecraft_dir=Path("~/.minecraft"),
         )
 
@@ -170,7 +170,7 @@ class TestAppConfig:
 
         config = AppConfig(
             minecraft_version="1.21.4",
-            loader=Loader.FORGE,
+            mod_loader=Loader.FORGE,
             minecraft_dir=Path("/custom/minecraft"),
             mods_dir=Path("/custom/mods"),
             shaders_dir=Path("/custom/shaders"),
@@ -179,7 +179,7 @@ class TestAppConfig:
             verify_hash=False,
         )
 
-        assert config.loader == Loader.FORGE
+        assert config.mod_loader == Loader.FORGE
         assert config.minecraft_dir == Path("/custom/minecraft")
         assert config.mods_dir == Path("/custom/mods")
         assert config.shaders_dir == Path("/custom/shaders")
@@ -199,6 +199,7 @@ class TestProjectConfig:
         assert config.slug == "sodium"
         assert config.version is None
         assert config.channel == ReleaseChannel.RELEASE
+        assert config.project_type is None
 
     def test_create_with_all_fields(self) -> None:
         """ProjectConfig can be created with all fields."""
@@ -207,11 +208,13 @@ class TestProjectConfig:
             slug="sodium",
             version="0.6.0",
             channel=ReleaseChannel.BETA,
+            project_type=ProjectType.MOD,
         )
 
         assert config.slug == "sodium"
         assert config.version == "0.6.0"
         assert config.channel == ReleaseChannel.BETA
+        assert config.project_type == ProjectType.MOD
 
 
 class TestInstalledFile:


### PR DESCRIPTION
  ## 概要

  シェーダー互換性チェックが常に「非対応」になる不具合を修正し、関連ドキュメントを更新しまし
  た。

  ## 関連 Issue

  Closes #49

  ## 変更種別

  - [ ] 新機能（feat）
  - [x] バグ修正（fix）
  - [x] ドキュメント（docs）
  - [ ] リファクタリング（refactor）
  - [ ] テスト（test）
  - [ ] その他（chore）

  ## 変更内容

  - Loader enum に IRIS/OPTIFINE を追加
  - AppConfig.loader を mod_loader に改名
  - AppConfig.shader_loader を追加（iris/optifine）
  - filter_compatible_versions() に shader_loader 引数を追加
  - SHADER の場合は shader_loader で判定（未指定時は全許可）
  - RESOURCEPACK の場合は loader チェックをスキップ
  - manager.py で project_type に応じて shader_loader を渡す
  - get_project のモック追加、shader loader のテスト追加、対話入力のテスト追加
  - ドキュメント/README の loader → mod_loader 置換

  ## テスト

  - `uv run ruff format src tests`
  - `uv run ruff check src tests`
  - `uv run ty check src`
  - `uv run pytest`

  ## チェックリスト

  - [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
  - [x] `uv run ruff format src tests` でフォーマット済み
  - [x] `uv run ruff check src tests` がエラーなしで通る
  - [x] `uv run ty check src` がエラーなしで通る
  - [x] `uv run pytest` が全てパス
  - [x] 新機能の場合、テストを追加した
  - [x] 必要に応じてドキュメントを更新した

  ## スクリーンショット（任意）

  ## 補足情報（任意）