### PR TITLE
feat(cli): add --check and --yes options to update command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,9 @@ mcpax search <query> [OPTIONS]          # Search Modrinth
   --limit/-l N                          #   Number of results (default: 10)
   --json                                #   Output in JSON format
 mcpax install [--all]                   # Install projects
-mcpax update [--check]                  # Check/apply updates
+mcpax update [OPTIONS]                  # Check/apply updates
+  --check/-c                            #   Check for updates without applying them
+  --yes/-y                              #   Skip confirmation prompts
 mcpax status                            # Show installation status
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ mcpax install sodium
 ### 5. 更新確認・適用
 
 ```bash
-# 更新を確認
+# 更新を確認（ダウンロードしない）
 mcpax update --check
 
-# 更新を適用
+# 更新を適用（確認プロンプトあり）
 mcpax update
+
+# 更新を適用（確認プロンプトをスキップ）
+mcpax update --yes
 ```
 
 ### 6. 一覧確認

--- a/src/mcpax/core/cache.py
+++ b/src/mcpax/core/cache.py
@@ -48,7 +48,7 @@ class ApiCache:
         ts = entry.get("ts")
         data = entry.get("data")
         if (
-            isinstance(ts, (int, float))
+            isinstance(ts, int | float)
             and isinstance(data, dict)
             and self._is_fresh(ts)
         ):
@@ -66,7 +66,7 @@ class ApiCache:
         ts = entry.get("ts")
         data = entry.get("data")
         if (
-            isinstance(ts, (int, float))
+            isinstance(ts, int | float)
             and isinstance(data, list)
             and self._is_fresh(ts)
         ):


### PR DESCRIPTION
feat(cli): add --check and --yes options to update command

- Updated the `mcpax update` command to include `--check` for checking updates without applying them.
- Added `--yes` option to skip confirmation prompts during updates.
- Updated documentation in README.md and CLAUDE.md to reflect these changes.
- Enhanced unit tests to cover new functionality and edge cases.

closes #12
