### PR TITLE
feat(tui): Add TUI foundation and entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,11 +97,88 @@ This project's primary development uses **jj (Jujutsu)** for version control. Wh
    jj new main
    ```
 
+#### Release Branch Strategy (v2.0 Development)
+
+**Context**: The current `main` branch represents v1.0 (stable). TUI features will be developed separately and released as v2.0. This strategy prevents work-in-progress code from entering `main` until v2.0 is complete.
+
+**Bookmark Structure**:
+- `main`: Always stable/released code (v1.0)
+- `release/2.0`: Long-lived branch for v2.0 release candidate (aggregates all TUI work)
+- `pr/<topic>`: Short-lived bookmarks for individual PRs
+
+**Standard Workflow for v2.0 Features**:
+
+1. Start from `main` (stable base):
+   ```bash
+   jj new main
+   ```
+
+2. Make changes and describe them (repeat as needed for small commits):
+   ```bash
+   # Make changes
+   jj describe -m "feat: add TUI component X"
+   jj new @  # Start next change if needed
+   ```
+
+3. When ready for PR, create a PR bookmark:
+   ```bash
+   jj bookmark create pr/<short-topic> -r @
+   ```
+
+4. Push and create PR targeting `release/2.0`:
+   ```bash
+   jj git push --bookmark pr/<short-topic>
+   # Then create PR on GitHub: base=release/2.0, head=pr/<short-topic>
+   ```
+
+5. After PR is merged:
+   ```bash
+   jj git fetch
+   jj new main  # Start next feature from stable base
+   ```
+
+**Exception: Hotfixes for v1.0**:
+
+If a fix is needed for the current stable version (v1.0):
+
+1. Start from `main`, make fix, create PR bookmark:
+   ```bash
+   jj new main
+   # Make fix
+   jj describe -m "fix: critical bug in X"
+   jj bookmark create pr/hotfix-<short> -r @
+   ```
+
+2. Push and create PR targeting `main`:
+   ```bash
+   jj git push --bookmark pr/hotfix-<short>
+   # Create PR: base=main, head=pr/hotfix-<short>
+   ```
+
+3. If the fix is also needed in v2.0, create a separate PR to `release/2.0` after the main PR merges.
+
+**Claude Code Guidelines**:
+- ✅ Create small, reviewable commits using `jj describe`
+- ✅ Organize commit history before PR (squash/reword if needed)
+- ✅ Create `pr/<topic>` bookmarks for PR submission
+- ✅ Inform user of PR target (base branch) and push command
+- ❌ Never execute `jj git push` (user handles push and PR creation)
+- ❌ Never move the `main` bookmark
+- ❌ Default PR target for v2.0 work is `release/2.0`, not `main`
+
+**Information to Provide User** (at end of work):
+- PR bookmark name (e.g., `pr/tui-core`)
+- PR base target (`main` or `release/2.0`)
+- Push command:
+  ```bash
+  jj git push --bookmark pr/<topic>
+  ```
+
 #### Common Commands
 
 | Command | Description |
 |---------|-------------|
-| `jj status` | Show working copy status |
+| `jj status` | Show working tree status |
 | `jj log` | Show commit history |
 | `jj diff` | Show changes |
 | `jj new main` | Create a new change on top of main |

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -1065,6 +1065,21 @@ def set(
         raise typer.Exit(code=1) from None
 
 
+@app.command()
+def tui() -> None:
+    """Launch the TUI interface."""
+    try:
+        from mcpax.tui import run_tui
+
+        run_tui()
+    except ImportError as e:
+        console.print(
+            "[red]Error:[/red] TUI dependencies not installed. "
+            "Run 'uv pip install -e \".\\[tui]\"' to install them."
+        )
+        raise typer.Exit(1) from e
+
+
 def main() -> None:
     """Entry point for the CLI."""
     app()

--- a/src/mcpax/tui/__init__.py
+++ b/src/mcpax/tui/__init__.py
@@ -1,1 +1,11 @@
-"""TUI interface for mcpax (future implementation)."""
+"""TUI interface for mcpax."""
+
+from mcpax.tui.app import McpaxApp
+
+__all__ = ["McpaxApp", "run_tui"]
+
+
+def run_tui() -> None:
+    """Run the TUI application."""
+    app = McpaxApp()
+    app.run()

--- a/src/mcpax/tui/app.py
+++ b/src/mcpax/tui/app.py
@@ -1,0 +1,22 @@
+"""Main TUI application for mcpax."""
+
+from textual.app import App, ComposeResult
+from textual.widgets import Footer, Header
+
+
+class McpaxApp(App[None]):
+    """Minecraft MOD/Shader/Resource Pack manager TUI."""
+
+    TITLE = "mcpax"
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        """Compose the app layout."""
+        yield Header()
+        yield Footer()
+
+    async def action_quit(self) -> None:
+        """Quit the application."""
+        self.exit()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3277,3 +3277,32 @@ minecraft_dir = "~/.minecraft"
         # Assert
         assert result.exit_code == 1
         assert "Unknown config key" in result.stdout or "Error" in result.stdout
+
+
+class TestTUI:
+    """Tests for tui command."""
+
+    def test_tui_command_launches_app(self) -> None:
+        """Test that tui command launches the TUI app."""
+        # Arrange
+        with patch("mcpax.tui.run_tui") as mock_run_tui:
+            # Act
+            result = runner.invoke(app, ["tui"])
+
+            # Assert
+            assert result.exit_code == 0
+            mock_run_tui.assert_called_once()
+
+    def test_tui_command_import_error(self) -> None:
+        """Test that tui command handles ImportError gracefully."""
+        # Arrange
+        with patch(
+            "mcpax.tui.run_tui",
+            side_effect=ImportError("No module named 'textual'"),
+        ):
+            # Act
+            result = runner.invoke(app, ["tui"])
+
+            # Assert
+            assert result.exit_code == 1
+            assert "TUI dependencies not installed" in result.stdout

--- a/tests/unit/tui/__init__.py
+++ b/tests/unit/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for TUI module."""

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -1,0 +1,23 @@
+"""Tests for mcpax.tui.app module."""
+
+import pytest
+
+from mcpax.tui.app import McpaxApp
+
+
+@pytest.mark.asyncio
+async def test_app_launches() -> None:
+    """Test that the app can be instantiated and has correct title."""
+    app = McpaxApp()
+    async with app.run_test():
+        assert app.title == "mcpax"
+
+
+@pytest.mark.asyncio
+async def test_app_quit_binding() -> None:
+    """Test that pressing q exits the app."""
+    app = McpaxApp()
+    async with app.run_test() as pilot:
+        await pilot.press("q")
+        # In Textual's run_test(), calling exit exits the context manager
+        # Reaching this point indicates the test has passed

--- a/tests/unit/tui/test_init.py
+++ b/tests/unit/tui/test_init.py
@@ -1,0 +1,17 @@
+"""Tests for mcpax.tui.__init__ module."""
+
+from unittest.mock import MagicMock, patch
+
+from mcpax.tui import run_tui
+
+
+def test_run_tui() -> None:
+    """Test that run_tui creates and runs the app."""
+    with patch("mcpax.tui.McpaxApp") as mock_app_class:
+        mock_app = MagicMock()
+        mock_app_class.return_value = mock_app
+
+        run_tui()
+
+        mock_app_class.assert_called_once()
+        mock_app.run.assert_called_once()


### PR DESCRIPTION
  ## 概要

  Textualを使用したTUIの基盤を構築し、`mcpax tui`コマンドを追加しました。Phase 3-1の最初のiss
  ueとして、TUI開発の土台となるエントリーポイントとアプリケーションクラスを実装しています。

  ## 関連 Issue

  Closes #59

  ## 変更種別

  - [x] 新機能（feat）
  - [ ] バグ修正（fix）
  - [ ] ドキュメント（docs）
  - [ ] リファクタリング（refactor）
  - [ ] テスト（test）
  - [ ] その他（chore）

  ## 変更内容

  ### 追加ファイル
  - `src/mcpax/tui/app.py` - McpaxAppクラス（Textual Appを継承）
    - Header/Footerを含む基本レイアウト
    - `q`キーでの終了アクション実装
  - `tests/unit/tui/test_app.py` - McpaxAppの単体テスト
  - `tests/unit/tui/test_init.py` - run_tui関数の単体テスト

  ### 変更ファイル
  - `src/mcpax/tui/__init__.py` - run_tui()エントリーポイント関数を追加
  - `src/mcpax/cli/app.py` - `mcpax tui`サブコマンドを追加
    - textual未インストール時のエラーハンドリング実装
  - `tests/unit/test_cli.py` - tuiコマンドのテストケースを追加

  ### 実装詳細
  - TUIアプリケーションは最小限の構成（Header/Footer）で実装
  - 後続のissue（#60-64）で画面やウィジェットを段階的に追加予定
  - textualの依存は`pyproject.toml`に既に定義済み（`tui = ["textual>=0.50"]`）

  ## テスト

  ### テスト実装
  - McpaxAppの起動テスト
  - `q`キーでの終了動作テスト
  - run_tui()関数のモックテスト
  - tuiコマンドの正常系・異常系（ImportError）テスト

  ### テスト結果
  ```bash
  $ uv run pytest
  ============================= 359 passed in 1.40s ===============================

  # カバレッジ
  - 全体カバレッジ: 88%
  - TUIモジュールカバレッジ: 100% (src/mcpax/tui/__init__.py, src/mcpax/tui/app.py)

  コード品質チェック

  $ uv run ruff format src tests
  1 file reformatted, 26 files left unchanged

  $ uv run ruff check src tests --fix
  All checks passed!

  $ uv run ty check src
  All checks passed!

  動作確認

  $ uv run mcpax --help | grep tui
  │ tui       Launch the TUI interface.                                          │

  チェックリスト

  - コードが ../CONTRIBUTING.md のガイドラインに従っている
  - uv run ruff format src tests でフォーマット済み
  - uv run ruff check src tests がエラーなしで通る
  - uv run ty check src がエラーなしで通る
  - uv run pytest が全てパス
  - 新機能の場合、テストを追加した
  - 必要に応じてドキュメントを更新した

  スクリーンショット（任意）

  （TUIは現状Header/Footerのみの最小構成のため省略）

  補足情報（任意）

  設計方針

  - TDDに従い、テストファーストで実装
  - 依存の注入可能性を考慮した設計
  - CLI/TUI → core の依存方向を維持（逆依存なし）

  次のステップ

  このPRでTUIの基盤が整いました。後続のissueで以下を段階的に実装予定:
  - #60: プロジェクト一覧画面
  - #61: プロジェクト詳細画面
  - #62: 検索機能
  - #63: インストール/更新機能
  - #64: 設定画面