### PR TITLE
feat(tui): Implement StatusBar widget to display Minecraft config

### DIFF
--- a/src/mcpax/tui/app.py
+++ b/src/mcpax/tui/app.py
@@ -3,6 +3,10 @@
 from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header
 
+from mcpax.core.config import ConfigValidationError, load_config
+from mcpax.core.models import AppConfig
+from mcpax.tui.widgets import StatusBar
+
 
 class McpaxApp(App[None]):
     """Minecraft MOD/Shader/Resource Pack manager TUI."""
@@ -12,9 +16,24 @@ class McpaxApp(App[None]):
         ("q", "quit", "Quit"),
     ]
 
+    def __init__(self) -> None:
+        """Initialize the TUI application."""
+        super().__init__()
+        self._config: AppConfig | None = None
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load configuration from default path."""
+        try:
+            self._config = load_config()
+        except (FileNotFoundError, ConfigValidationError):
+            # Config will be None if not found or invalid
+            self._config = None
+
     def compose(self) -> ComposeResult:
         """Compose the app layout."""
         yield Header()
+        yield StatusBar(config=self._config)
         yield Footer()
 
     async def action_quit(self) -> None:

--- a/src/mcpax/tui/widgets/__init__.py
+++ b/src/mcpax/tui/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""TUI widgets for mcpax."""
+
+from .status_bar import StatusBar
+
+__all__ = ["StatusBar"]

--- a/src/mcpax/tui/widgets/status_bar.py
+++ b/src/mcpax/tui/widgets/status_bar.py
@@ -1,0 +1,50 @@
+"""StatusBar widget for displaying Minecraft configuration."""
+
+from typing import Any
+
+from textual.widgets import Static
+
+from mcpax.core.models import AppConfig
+
+
+class StatusBar(Static):
+    """StatusBar widget to display Minecraft version and loader information."""
+
+    def __init__(self, config: AppConfig | None = None, **kwargs: Any) -> None:
+        """Initialize the StatusBar.
+
+        Args:
+            config: Application configuration (optional)
+            **kwargs: Additional arguments passed to Static
+        """
+        super().__init__(**kwargs)
+        self._config = config
+
+    def render(self) -> str:
+        """Render the status bar content.
+
+        Returns:
+            Formatted string with Minecraft version and loader information,
+            or a message if config is not loaded.
+        """
+        if self._config is None:
+            return "Config not loaded"
+
+        parts = [
+            f"MC: {self._config.minecraft_version}",
+            f"Loader: {self._config.mod_loader.value.capitalize()}",
+        ]
+
+        if self._config.shader_loader is not None:
+            parts.append(f"Shader: {self._config.shader_loader.value.capitalize()}")
+
+        return "  ".join(parts)
+
+    def update_config(self, config: AppConfig | None) -> None:
+        """Update the configuration and refresh display.
+
+        Args:
+            config: New application configuration
+        """
+        self._config = config
+        self.refresh()

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -1,8 +1,14 @@
 """Tests for mcpax.tui.app module."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
+from mcpax.core.config import ConfigValidationError
+from mcpax.core.models import AppConfig, Loader
 from mcpax.tui.app import McpaxApp
+from mcpax.tui.widgets import StatusBar
 
 
 @pytest.mark.asyncio
@@ -21,3 +27,70 @@ async def test_app_quit_binding() -> None:
         await pilot.press("q")
         # In Textual's run_test(), calling exit exits the context manager
         # Reaching this point indicates the test has passed
+
+
+@pytest.mark.asyncio
+async def test_app_has_status_bar() -> None:
+    """Test that the app includes StatusBar widget."""
+    app = McpaxApp()
+    async with app.run_test():
+        # Check that StatusBar is in the widget tree
+        status_bar = app.query_one(StatusBar)
+        assert status_bar is not None
+
+
+@pytest.mark.asyncio
+async def test_app_loads_config_successfully() -> None:
+    """Test that the app loads config successfully when available."""
+    test_config = AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        shader_loader=None,
+        minecraft_dir=Path("/tmp/.minecraft"),
+    )
+
+    with patch("mcpax.tui.app.load_config", return_value=test_config):
+        app = McpaxApp()
+        async with app.run_test():
+            # Check that config was loaded
+            assert app._config is not None
+            assert app._config.minecraft_version == "1.21.4"
+
+            # Check that StatusBar shows config
+            status_bar = app.query_one(StatusBar)
+            rendered = status_bar.render()
+            assert "MC: 1.21.4" in rendered
+            assert "Loader: Fabric" in rendered
+
+
+@pytest.mark.asyncio
+async def test_app_handles_missing_config() -> None:
+    """Test that the app handles missing config gracefully."""
+    with patch("mcpax.tui.app.load_config", side_effect=FileNotFoundError()):
+        app = McpaxApp()
+        async with app.run_test():
+            # Config should be None
+            assert app._config is None
+
+            # StatusBar should show config not loaded message
+            status_bar = app.query_one(StatusBar)
+            rendered = status_bar.render()
+            assert "Config not loaded" in rendered
+
+
+@pytest.mark.asyncio
+async def test_app_handles_invalid_config() -> None:
+    """Test that the app handles invalid config gracefully."""
+    with patch(
+        "mcpax.tui.app.load_config",
+        side_effect=ConfigValidationError("Invalid config"),
+    ):
+        app = McpaxApp()
+        async with app.run_test():
+            # Config should be None
+            assert app._config is None
+
+            # StatusBar should show config not loaded message
+            status_bar = app.query_one(StatusBar)
+            rendered = status_bar.render()
+            assert "Config not loaded" in rendered

--- a/tests/unit/tui/widgets/__init__.py
+++ b/tests/unit/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for TUI widgets."""

--- a/tests/unit/tui/widgets/test_status_bar.py
+++ b/tests/unit/tui/widgets/test_status_bar.py
@@ -1,0 +1,133 @@
+"""Tests for StatusBar widget."""
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+from mcpax.core.models import AppConfig, Loader
+from mcpax.tui.widgets import StatusBar
+
+
+def create_test_config() -> AppConfig:
+    """Create a test AppConfig instance."""
+    return AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        shader_loader=Loader.IRIS,
+        minecraft_dir=Path("/tmp/.minecraft"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_bar_with_config() -> None:
+    """Test StatusBar initialization with config."""
+    config = create_test_config()
+    status_bar = StatusBar(config=config)
+
+    # Status bar should be instantiated
+    assert status_bar is not None
+
+
+@pytest.mark.asyncio
+async def test_status_bar_without_config() -> None:
+    """Test StatusBar initialization without config."""
+    status_bar = StatusBar(config=None)
+
+    # Status bar should be instantiated
+    assert status_bar is not None
+
+
+@pytest.mark.asyncio
+async def test_status_bar_render_with_config() -> None:
+    """Test StatusBar renders correct text with config."""
+    config = create_test_config()
+    status_bar = StatusBar(config=config)
+
+    # Render should return formatted config info
+    rendered = status_bar.render()
+    assert "MC: 1.21.4" in rendered
+    assert "Loader: Fabric" in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_bar_render_without_config() -> None:
+    """Test StatusBar renders message when config is None."""
+    status_bar = StatusBar(config=None)
+
+    # Render should return message indicating config not loaded
+    rendered = status_bar.render()
+    assert "Config not loaded" in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_bar_update_config() -> None:
+    """Test StatusBar can update config after initialization."""
+    status_bar = StatusBar(config=None)
+
+    # Initially should show no config message
+    rendered = status_bar.render()
+    assert "Config not loaded" in rendered
+
+    # Update with config
+    config = create_test_config()
+    status_bar.update_config(config)
+
+    # After update, should show config info
+    rendered = status_bar.render()
+    assert "MC: 1.21.4" in rendered
+    assert "Loader: Fabric" in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_bar_in_app() -> None:
+    """Test StatusBar integration in a minimal app."""
+
+    class TestApp(App[None]):
+        """Minimal app for testing StatusBar."""
+
+        def compose(self) -> ComposeResult:
+            config = create_test_config()
+            yield StatusBar(config=config)
+
+    app = TestApp()
+    async with app.run_test():
+        # Check that StatusBar is rendered
+        status_bar = app.query_one(StatusBar)
+        assert status_bar is not None
+
+        # Check rendered content
+        rendered = status_bar.render()
+        assert "MC: 1.21.4" in rendered
+        assert "Loader: Fabric" in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_bar_with_shader_loader() -> None:
+    """Test StatusBar displays shader loader when available."""
+    config = create_test_config()
+    status_bar = StatusBar(config=config)
+
+    rendered = status_bar.render()
+    # Should show both mod loader and shader loader
+    assert "Loader: Fabric" in rendered
+    # Shader loader should be shown separately or indicated
+    assert "Iris" in rendered or "iris" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_status_bar_without_shader_loader() -> None:
+    """Test StatusBar when shader_loader is None."""
+    config = AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        shader_loader=None,
+        minecraft_dir=Path("/tmp/.minecraft"),
+    )
+    status_bar = StatusBar(config=config)
+
+    rendered = status_bar.render()
+    assert "MC: 1.21.4" in rendered
+    assert "Loader: Fabric" in rendered
+    # Should not mention shader loader
+    assert "Iris" not in rendered


### PR DESCRIPTION
## Summary

- Minecraft バージョンと mod loader を表示する StatusBar ウィジェットを実装
- Header と Footer の間に StatusBar を配置し、設定ファイルから読み込んだ情報を表示
- 設定ファイルが存在しない、または無効な場合は "Config not loaded" メッセージを表示

## Implementation Details

### 新規ファイル
- `src/mcpax/tui/widgets/__init__.py` - widgets パッケージ
- `src/mcpax/tui/widgets/status_bar.py` - StatusBar ウィジェット本体
  - `render()`: 設定情報をフォーマットして返す
  - `update_config()`: 設定を動的に更新
- `tests/unit/tui/widgets/test_status_bar.py` - 包括的なテストカバレッジ（8 テストケース）

### 変更ファイル
- `src/mcpax/tui/app.py`
  - `__init__()` で設定を読み込み
  - `_load_config()` でエラーハンドリング
  - `compose()` で StatusBar を統合
- `tests/unit/tui/test_app.py` - 統合テスト追加（新規 4 テストケース）

### 表示例
設定がある場合

MC: 1.21.4  Loader: Fabric  Shader: Iris

shader_loader がない場合

MC: 1.21.4  Loader: Fabric

設定がない場合

Config not loaded

## Test Plan

- [x] StatusBar 単体テスト（8 ケース）が全て成功
- [x] McpaxApp 統合テスト（6 ケース）が全て成功
- [x] TUI コードのカバレッジが 100%
- [x] `ruff check` と `ruff format` が合格
- [x] `ty check` が合格
- [x] TUI を起動して StatusBar が正しく表示されることを手動確認
  ```bash
  uv run python -c "from mcpax.tui import run_tui; run_tui()"
- 設定ファイルを削除して "Config not loaded" が表示されることを確認

Notes

- TDD (t-wada スタイル) に従って実装: Red → Green → Refactor
- コンストラクタ注入でテスタビリティを確保
- Footer はキーバインド表示専用として、StatusBar を別ウィジェットとして実装

Fixes #60

🤖 Generated with https://claude.com/claude-code