### PR TITLE
feat(tui): Add Minecraft-inspired stylesheet with dark theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcpax"]
+include = [
+    "src/mcpax/**/*.tcss",
+]

--- a/src/mcpax/tui/app.py
+++ b/src/mcpax/tui/app.py
@@ -1,5 +1,7 @@
 """Main TUI application for mcpax."""
 
+from pathlib import Path
+
 from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header
 
@@ -11,6 +13,7 @@ from mcpax.tui.widgets import StatusBar
 class McpaxApp(App[None]):
     """Minecraft MOD/Shader/Resource Pack manager TUI."""
 
+    CSS_PATH = Path(__file__).parent / "styles" / "app.tcss"
     TITLE = "mcpax"
     BINDINGS = [
         ("q", "quit", "Quit"),

--- a/src/mcpax/tui/styles/__init__.py
+++ b/src/mcpax/tui/styles/__init__.py
@@ -1,0 +1,1 @@
+"""TUI styles module."""

--- a/src/mcpax/tui/styles/app.tcss
+++ b/src/mcpax/tui/styles/app.tcss
@@ -1,0 +1,150 @@
+/*
+ * mcpax TUI Stylesheet
+ * Minecraft-inspired dark theme
+ */
+
+/* ============================================================================
+ * Color Palette (Minecraft-inspired Dark Theme)
+ * ============================================================================ */
+
+/* Background colors */
+$background: #1a1a1a;           /* Main background (Minecraft night sky) */
+$surface: #2d2d2d;              /* Widget background */
+$surface-elevated: #3a3a3a;     /* Modal/elevated surface */
+
+/* Primary colors */
+$primary: #5cb85c;              /* Grass block green */
+$primary-muted: #3d8b3d;        /* Muted green */
+$secondary: #4a90d9;            /* Water blue */
+
+/* Text colors */
+$text: #e0e0e0;                 /* Primary text */
+$text-muted: #808080;           /* Secondary/muted text */
+
+/* Border colors */
+$border: #404040;               /* Border color */
+
+/* Status colors */
+$success: #5cb85c;              /* Installed */
+$warning: #f0ad4e;              /* Update available */
+$error: #d9534f;                /* Error/incompatible */
+$neutral: #808080;              /* Not installed */
+
+/* ============================================================================
+ * Global Styles
+ * ============================================================================ */
+
+Screen {
+    background: $background;
+}
+
+/* ============================================================================
+ * Header
+ * ============================================================================ */
+
+Header {
+    background: $primary;
+    color: $background;
+    text-style: bold;
+}
+
+/* ============================================================================
+ * Footer
+ * ============================================================================ */
+
+Footer {
+    background: $surface;
+    color: $text;
+}
+
+/* ============================================================================
+ * StatusBar Widget
+ * ============================================================================ */
+
+StatusBar {
+    background: $surface;
+    color: $text;
+    height: auto;
+    padding: 1;
+}
+
+StatusBar > .status-item {
+    color: $text;
+}
+
+StatusBar > .status-label {
+    color: $text-muted;
+}
+
+/* ============================================================================
+ * Utility Classes
+ * ============================================================================ */
+
+.success {
+    color: $success;
+}
+
+.warning {
+    color: $warning;
+}
+
+.error {
+    color: $error;
+}
+
+.neutral {
+    color: $neutral;
+}
+
+.muted {
+    color: $text-muted;
+}
+
+/* ============================================================================
+ * Future Widget Placeholders (commented out for now)
+ * ============================================================================ */
+
+/*
+ProjectList {
+    background: $surface;
+    border: solid $border;
+}
+
+ProjectListItem {
+    background: $surface;
+    color: $text;
+}
+
+ProjectListItem:hover {
+    background: $surface-elevated;
+}
+
+ProjectListItem.-selected {
+    background: $primary-muted;
+    color: $text;
+}
+
+Dialog {
+    background: $surface-elevated;
+    border: thick $primary;
+}
+
+Button {
+    background: $primary;
+    color: $background;
+}
+
+Button:hover {
+    background: $primary-muted;
+}
+
+Input {
+    background: $surface;
+    border: solid $border;
+    color: $text;
+}
+
+Input:focus {
+    border: solid $primary;
+}
+*/

--- a/tests/unit/tui/test_styles.py
+++ b/tests/unit/tui/test_styles.py
@@ -1,0 +1,43 @@
+"""Tests for TUI styles and CSS configuration."""
+
+from pathlib import Path
+
+import pytest
+
+from mcpax.tui.app import McpaxApp
+
+
+@pytest.mark.asyncio
+async def test_app_has_css_path() -> None:
+    """Test that McpaxApp has CSS_PATH attribute."""
+    app = McpaxApp()
+    async with app.run_test():
+        assert hasattr(app, "CSS_PATH")
+        assert app.CSS_PATH is not None
+
+
+@pytest.mark.asyncio
+async def test_css_path_points_to_app_tcss() -> None:
+    """Test that CSS_PATH points to app.tcss in styles directory."""
+    app = McpaxApp()
+    async with app.run_test():
+        css_path = app.CSS_PATH
+        # CSS_PATH should be a Path object or string
+        if isinstance(css_path, str):
+            css_path = Path(css_path)
+
+        assert css_path.name == "app.tcss"
+        assert css_path.parent.name == "styles"
+
+
+@pytest.mark.asyncio
+async def test_css_file_exists() -> None:
+    """Test that the CSS file exists at the specified path."""
+    app = McpaxApp()
+    async with app.run_test():
+        css_path = app.CSS_PATH
+        if isinstance(css_path, str):
+            css_path = Path(css_path)
+
+        assert css_path.exists(), f"CSS file not found at {css_path}"
+        assert css_path.is_file(), f"CSS path is not a file: {css_path}"


### PR DESCRIPTION
## 概要

TUIアプリケーションにMinecraft風のダークテーマスタイルシステムを追加しました。Textual
CSSを使用して統一されたデザインを実現し、`.tcss`ファイルの配布設定も含まれています。

## 関連 Issue

Closes #61 

## 変更種別

- [x] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

- **スタイルシステムの導入**
  - `src/mcpax/tui/styles/`ディレクトリを作成し、TUIスタイルを分離管理
  - Minecraft風のカラーパレット（草ブロックの緑、水の青など）を定義
  - Header、Footer、StatusBarなどのウィジェットスタイルを設定

- **CSS読み込みの実装**
  - `McpaxApp`に`CSS_PATH`属性を追加し、`app.tcss`を読み込む
  - `pathlib.Path`を使用してパスを動的に解決

- **ビルド設定の更新**
  - `pyproject.toml`にて`*.tcss`ファイルをwheel配布に含めるよう設定
  - ユーザー環境でもスタイルが正しく適用されることを保証

- **テストの追加**
  - `tests/unit/tui/test_styles.py`でCSS_PATH属性の存在と正当性を検証
  - CSSファイルの実在確認テストを実装

## テスト

- `uv run pytest tests/unit/tui/test_styles.py -v`で3つのテストケースが全てパス
  - CSS_PATH属性の存在確認
  - CSS_PATHが正しいファイルを指していることの確認
  - CSSファイルの実在確認

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

N/A（CSSの視覚的な効果は将来のウィジェット実装時に確認可能）

## 補足情報（任意）

- このPRはv2.0 TUI開発の基盤となるスタイルシステムを確立します
- `app.tcss`には将来実装予定のウィジェット用のスタイル定義もコメントアウトで含まれています
- カラーパレットはMinecraftの世界観（夜空の背景、草ブロック、水など）からインスピレーション
を得ています