### PR TITLE
fix(tui): Handle ConfigValidationError in SearchScreen

### DIFF
--- a/src/mcpax/tui/screens/__init__.py
+++ b/src/mcpax/tui/screens/__init__.py
@@ -2,5 +2,6 @@
 
 from .detail import ProjectDetailScreen
 from .main import MainScreen
+from .search import SearchScreen
 
-__all__ = ["MainScreen", "ProjectDetailScreen"]
+__all__ = ["MainScreen", "ProjectDetailScreen", "SearchScreen"]

--- a/src/mcpax/tui/screens/main.py
+++ b/src/mcpax/tui/screens/main.py
@@ -12,6 +12,7 @@ from mcpax.core.config import ConfigValidationError, load_projects
 from mcpax.core.manager import ProjectManager
 from mcpax.core.models import AppConfig, ProjectConfig, ProjectType, UpdateCheckResult
 from mcpax.tui.screens.detail import ProjectDetailScreen
+from mcpax.tui.screens.search import SearchScreen
 from mcpax.tui.widgets import ProjectTable, SearchInput, StatusBar
 
 
@@ -144,21 +145,22 @@ class MainScreen(Screen[None]):
 
         Args:
             message: SearchRequested message with query and project_type
-
-        Note:
-            Actual search functionality will be implemented in #66.
-            For now, just notify the user.
         """
         query: str = message.query
         project_type: ProjectType | None = message.project_type
 
-        # Placeholder notification (search logic will be in #66)
+        # Only open SearchScreen if query is not empty
         if query:
-            type_str = f" (type: {project_type.value})" if project_type else ""
-            self.notify(
-                f"Search requested: '{query}'{type_str}",
-                severity="information",
+            self.app.push_screen(
+                SearchScreen(query=query, project_type=project_type),
+                callback=self._on_search_dismissed,
             )
-        else:
-            # Empty query - could reset to show all projects
-            self.notify("Search cleared", severity="information")
+
+    def _on_search_dismissed(self, added: bool | None) -> None:
+        """Handle search screen dismissal.
+
+        Args:
+            added: True if project was added, False or None otherwise
+        """
+        if added:
+            self._load_and_check_updates()

--- a/src/mcpax/tui/screens/search.py
+++ b/src/mcpax/tui/screens/search.py
@@ -1,0 +1,130 @@
+"""Search screen for displaying Modrinth search results."""
+
+import json
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Static
+from textual.worker import Worker, WorkerState
+
+from mcpax.core.api import ModrinthClient
+from mcpax.core.config import ConfigValidationError, load_projects, save_projects
+from mcpax.core.models import (
+    ProjectConfig,
+    ProjectType,
+    SearchHit,
+    SearchResult,
+)
+from mcpax.tui.widgets.search_result_table import SearchResultTable
+
+MODRINTH_SEARCH_LIMIT = 50
+
+
+class SearchScreen(Screen[bool]):
+    """Screen for displaying search results and adding projects."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Back"),
+        Binding("a", "add_project", "Add"),
+    ]
+
+    def __init__(
+        self, query: str, project_type: ProjectType | None
+    ) -> None:
+        """Initialize SearchScreen.
+
+        Args:
+            query: Search query string
+            project_type: Optional project type filter
+        """
+        super().__init__()
+        self._query = query
+        self._project_type = project_type
+        self._added = False
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets.
+
+        Yields:
+            Screen widgets
+        """
+        yield Static(f"Search: '{self._query}'", id="search-header")
+        yield SearchResultTable(id="search-results")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Execute search when screen is mounted."""
+        self.run_worker(self._search_worker(), exclusive=True)
+
+    async def _search_worker(self) -> SearchResult:
+        """Execute Modrinth search.
+
+        Returns:
+            SearchResult from API
+        """
+        facets = None
+        if self._project_type:
+            facets = json.dumps([[f"project_type:{self._project_type.value}"]])
+
+        async with ModrinthClient() as client:
+            return await client.search(
+                query=self._query, limit=MODRINTH_SEARCH_LIMIT, facets=facets
+            )
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        """Handle worker state changes.
+
+        Args:
+            event: Worker state change event
+        """
+        if event.state == WorkerState.SUCCESS:
+            result = event.worker.result
+            if isinstance(result, SearchResult):
+                table = self.query_one(SearchResultTable)
+                table.load_results(result.hits)
+
+                if not result.hits:
+                    self.notify("No results found", severity="warning")
+        elif event.state == WorkerState.ERROR:
+            self.notify(f"Search failed: {event.worker.error}", severity="error")
+
+    def action_cancel(self) -> None:
+        """Close the search screen."""
+        self.dismiss(self._added)
+
+    def action_add_project(self) -> None:
+        """Add the selected project to projects.toml."""
+        table = self.query_one(SearchResultTable)
+        selected = table.selected_result
+
+        if not selected:
+            self.notify("No project selected", severity="warning")
+            return
+
+        self._add_project_to_config(selected)
+
+    def _add_project_to_config(self, hit: SearchHit) -> None:
+        """Add project to projects.toml.
+
+        Args:
+            hit: Selected search hit to add
+        """
+        try:
+            projects = load_projects()
+        except FileNotFoundError:
+            projects = []
+        except ConfigValidationError as e:
+            self.notify(f"設定ファイルの読み込みに失敗しました: {e}", severity="error")
+            return
+
+        # Check for duplicates
+        if any(p.slug == hit.slug for p in projects):
+            self.notify(f"'{hit.slug}' は既に登録済みです", severity="warning")
+            return
+
+        # Add new project
+        projects.append(ProjectConfig(slug=hit.slug, project_type=hit.project_type))
+        save_projects(projects)
+        self._added = True
+        self.notify(f"'{hit.slug}' を追加しました", severity="information")

--- a/src/mcpax/tui/styles/app.tcss
+++ b/src/mcpax/tui/styles/app.tcss
@@ -218,6 +218,55 @@ SearchInput > Select {
 }
 
 /* ============================================================================
+ * SearchScreen
+ * ============================================================================ */
+
+SearchScreen {
+    layout: vertical;
+}
+
+#search-header {
+    dock: top;
+    height: auto;
+    background: $surface;
+    color: $primary;
+    text-style: bold;
+    padding: 1;
+}
+
+SearchScreen > SearchResultTable {
+    height: 1fr;
+}
+
+SearchScreen > Footer {
+    dock: bottom;
+}
+
+/* ============================================================================
+ * SearchResultTable Widget
+ * ============================================================================ */
+
+SearchResultTable {
+    background: $surface;
+    border: solid $border;
+    height: 100%;
+}
+
+SearchResultTable > .datatable--header {
+    background: $surface-elevated;
+    color: $text;
+    text-style: bold;
+}
+
+SearchResultTable > .datatable--cursor {
+    background: $primary-muted;
+}
+
+SearchResultTable > .datatable--hover {
+    background: $surface-elevated;
+}
+
+/* ============================================================================
  * Future Widget Placeholders (commented out for now)
  * ============================================================================ */
 

--- a/src/mcpax/tui/widgets/__init__.py
+++ b/src/mcpax/tui/widgets/__init__.py
@@ -2,6 +2,7 @@
 
 from .project_table import ProjectTable
 from .search_input import SearchInput
+from .search_result_table import SearchResultTable
 from .status_bar import StatusBar
 
-__all__ = ["ProjectTable", "SearchInput", "StatusBar"]
+__all__ = ["ProjectTable", "SearchInput", "SearchResultTable", "StatusBar"]

--- a/src/mcpax/tui/widgets/search_input.py
+++ b/src/mcpax/tui/widgets/search_input.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 from textual.app import ComposeResult
 from textual.message import Message
-from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import Input, Select
 
@@ -28,16 +27,13 @@ class SearchInput(Widget):
             self.query = query
             self.project_type = project_type
 
-    def __init__(self, debounce_delay: float = 0.3, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """Initialize the SearchInput widget.
 
         Args:
-            debounce_delay: Delay before emitting search events (default: 0.3)
             **kwargs: Additional arguments passed to Widget
         """
         super().__init__(**kwargs)
-        self._debounce_delay = debounce_delay
-        self._debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the SearchInput widget.
@@ -71,29 +67,11 @@ class SearchInput(Widget):
 
         self.post_message(self.SearchRequested(query, project_type))
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        """Handle Input.Changed event.
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle Input.Submitted event (Enter key pressed).
 
         Args:
-            event: Input.Changed event
-        """
-        # Cancel previous timer if exists
-        if self._debounce_timer is not None:
-            self._debounce_timer.stop()
-
-        # Set new timer
-        if self._debounce_delay > 0:
-            self._debounce_timer = self.set_timer(
-                self._debounce_delay, self._emit_search_requested
-            )
-        else:
-            self._emit_search_requested()
-
-    def on_select_changed(self, event: Select.Changed) -> None:
-        """Handle Select.Changed event.
-
-        Args:
-            event: Select.Changed event
+            event: Input.Submitted event
         """
         self._emit_search_requested()
 

--- a/src/mcpax/tui/widgets/search_result_table.py
+++ b/src/mcpax/tui/widgets/search_result_table.py
@@ -1,0 +1,100 @@
+"""SearchResultTable widget for displaying search results."""
+
+from typing import Any
+
+from textual.widgets import DataTable
+
+from mcpax.core.models import SearchHit
+
+
+class SearchResultTable(DataTable[str]):
+    """DataTable widget for displaying search results."""
+
+    COLUMNS = [
+        ("slug", "Slug", 20),
+        ("title", "Title", 25),
+        ("type", "Type", 12),
+        ("downloads", "Downloads", 12),
+    ]
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the SearchResultTable.
+
+        Args:
+            **kwargs: Additional arguments passed to DataTable
+        """
+        super().__init__(**kwargs)
+        self.cursor_type = "row"
+        self._results: list[SearchHit] = []
+
+    def on_mount(self) -> None:
+        """Set up the table when mounted."""
+        self._setup_columns()
+
+    def _setup_columns(self) -> None:
+        """Set up table columns."""
+        for col_id, label, width in self.COLUMNS:
+            self.add_column(label, key=col_id, width=width)
+
+    @property
+    def results(self) -> list[SearchHit]:
+        """Get the current list of search results.
+
+        Returns:
+            List of SearchHit objects
+        """
+        return self._results
+
+    @property
+    def selected_result(self) -> SearchHit | None:
+        """Get the currently selected search result.
+
+        Returns:
+            Selected SearchHit or None if nothing is selected
+        """
+        if not self.cursor_coordinate:
+            return None
+
+        row_index = self.cursor_coordinate.row
+        if 0 <= row_index < len(self._results):
+            return self._results[row_index]
+
+        return None
+
+    def load_results(self, results: list[SearchHit]) -> None:
+        """Load search results into the table.
+
+        Args:
+            results: List of SearchHit objects to display
+        """
+        self._results = results
+        self._populate_table()
+
+    def _populate_table(self) -> None:
+        """Populate the table with search result data."""
+        self.clear()
+
+        for result in self._results:
+            self.add_row(
+                result.slug,
+                result.title,
+                result.project_type.value,
+                self._format_downloads(result.downloads),
+                key=result.slug,
+            )
+
+    def _format_downloads(self, downloads: int) -> str:
+        """Format download count for display.
+
+        Args:
+            downloads: Download count
+
+        Returns:
+            Formatted string (e.g., "1.2M", "500.0K", "999")
+        """
+        if downloads >= 1_000_000:
+            return f"{downloads / 1_000_000:.1f}M"
+        elif downloads >= 1_000:
+            return f"{downloads / 1_000:.1f}K"
+        else:
+            return str(downloads)

--- a/tests/unit/tui/screens/test_search.py
+++ b/tests/unit/tui/screens/test_search.py
@@ -1,0 +1,327 @@
+"""Tests for SearchScreen."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from textual.app import App
+
+from mcpax.core.models import (
+    ProjectType,
+    SearchHit,
+    SearchResult,
+)
+from mcpax.tui.screens.search import MODRINTH_SEARCH_LIMIT, SearchScreen
+
+
+def create_test_search_hit(
+    slug: str,
+    title: str,
+    project_type: ProjectType = ProjectType.MOD,
+    downloads: int = 1000,
+) -> SearchHit:
+    """Create a test SearchHit instance."""
+    return SearchHit(
+        slug=slug,
+        title=title,
+        description="Test description",
+        project_type=project_type,
+        downloads=downloads,
+        icon_url=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_screen_initialization() -> None:
+    """Test SearchScreen initialization."""
+    screen = SearchScreen(query="sodium", project_type=None)
+    assert screen is not None
+    assert screen._query == "sodium"
+    assert screen._project_type is None
+
+
+@pytest.mark.asyncio
+async def test_search_screen_with_project_type_filter() -> None:
+    """Test SearchScreen initialization with project type filter."""
+    screen = SearchScreen(query="shader", project_type=ProjectType.SHADER)
+    assert screen._query == "shader"
+    assert screen._project_type == ProjectType.SHADER
+
+
+@pytest.mark.asyncio
+async def test_search_screen_has_escape_binding() -> None:
+    """Test SearchScreen has escape keybinding."""
+    screen = SearchScreen(query="test", project_type=None)
+
+    # Check that 'escape' is bound to cancel action
+    bindings = {binding.key: binding.action for binding in screen.BINDINGS}
+    assert "escape" in bindings
+    assert bindings["escape"] == "cancel"
+
+
+@pytest.mark.asyncio
+async def test_search_screen_has_add_binding() -> None:
+    """Test SearchScreen has add (a) keybinding."""
+    screen = SearchScreen(query="test", project_type=None)
+
+    # Check that 'a' is bound to add_project action
+    bindings = {binding.key: binding.action for binding in screen.BINDINGS}
+    assert "a" in bindings
+    assert bindings["a"] == "add_project"
+
+
+@pytest.mark.asyncio
+async def test_search_screen_executes_search() -> None:
+    """Test SearchScreen executes search on mount."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="sodium", project_type=None                )
+            )
+
+    mock_search_result = SearchResult(
+        hits=[
+            create_test_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+            create_test_search_hit("lithium", "Lithium", ProjectType.MOD, 2000000),
+        ],
+        total_hits=2,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    with patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        app = TestApp()
+        async with app.run_test():
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Verify search was called
+            mock_client.search.assert_called_once_with(
+                query="sodium", limit=MODRINTH_SEARCH_LIMIT, facets=None
+            )
+
+
+@pytest.mark.asyncio
+async def test_search_screen_with_project_type_facet() -> None:
+    """Test SearchScreen applies project_type as facet."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="shader",
+                    project_type=ProjectType.SHADER,
+                )
+            )
+
+    mock_search_result = SearchResult(
+        hits=[
+            create_test_search_hit("iris", "Iris Shaders", ProjectType.SHADER, 2000000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    with patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        app = TestApp()
+        async with app.run_test():
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Verify search was called with facets
+            expected_facets = json.dumps([["project_type:shader"]])
+            mock_client.search.assert_called_once_with(
+                query="shader", limit=MODRINTH_SEARCH_LIMIT, facets=expected_facets
+            )
+
+
+@pytest.mark.asyncio
+async def test_search_screen_escape_closes() -> None:
+    """Test escape key closes the search screen."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="test", project_type=None                )
+            )
+
+    with patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(
+            return_value=SearchResult(
+                hits=[], total_hits=0, offset=0, limit=MODRINTH_SEARCH_LIMIT
+            )
+        )
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Verify search screen is active
+            assert isinstance(app.screen, SearchScreen)
+
+            # Press escape to close
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Screen should be dismissed
+            assert not isinstance(app.screen, SearchScreen)
+
+
+@pytest.mark.asyncio
+async def test_search_screen_add_project() -> None:
+    """Test adding a project from search results."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="sodium", project_type=None                )
+            )
+
+    mock_search_result = SearchResult(
+        hits=[
+            create_test_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    with (
+        patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
+        patch("mcpax.tui.screens.search.load_projects") as mock_load,
+        patch("mcpax.tui.screens.search.save_projects") as mock_save,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_load.return_value = []
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Press 'a' to add selected project
+            await pilot.press("a")
+            await pilot.pause()
+
+            # Verify save_projects was called
+            mock_save.assert_called_once()
+            saved_projects = mock_save.call_args[0][0]
+            assert len(saved_projects) == 1
+            assert saved_projects[0].slug == "sodium"
+            assert saved_projects[0].project_type == ProjectType.MOD
+
+
+@pytest.mark.asyncio
+async def test_search_screen_add_duplicate_project() -> None:
+    """Test adding a duplicate project shows warning."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="sodium", project_type=None                )
+            )
+
+    mock_search_result = SearchResult(
+        hits=[
+            create_test_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    from mcpax.core.models import ProjectConfig, ReleaseChannel
+
+    existing_projects = [
+        ProjectConfig(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            channel=ReleaseChannel.RELEASE,
+        ),
+    ]
+
+    with (
+        patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
+        patch("mcpax.tui.screens.search.load_projects") as mock_load,
+        patch("mcpax.tui.screens.search.save_projects") as mock_save,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_load.return_value = existing_projects
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Press 'a' to add selected project
+            await pilot.press("a")
+            await pilot.pause()
+
+            # Verify save_projects was NOT called (duplicate)
+            mock_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_screen_add_project_with_invalid_config() -> None:
+    """Test adding a project when projects.toml is invalid shows error."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(
+                SearchScreen(
+                    query="sodium", project_type=None                )
+            )
+
+    mock_search_result = SearchResult(
+        hits=[
+            create_test_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    from mcpax.core.config import ConfigValidationError
+
+    with (
+        patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
+        patch("mcpax.tui.screens.search.load_projects") as mock_load,
+        patch("mcpax.tui.screens.search.save_projects") as mock_save,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_load.side_effect = ConfigValidationError("Invalid TOML")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Wait for worker to complete
+            await app.workers.wait_for_complete()
+
+            # Press 'a' to add selected project
+            await pilot.press("a")
+            await pilot.pause()
+
+            # Verify save_projects was NOT called (config error)
+            mock_save.assert_not_called()

--- a/tests/unit/tui/widgets/test_search_result_table.py
+++ b/tests/unit/tui/widgets/test_search_result_table.py
@@ -1,0 +1,139 @@
+"""Tests for SearchResultTable widget."""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from mcpax.core.models import ProjectType, SearchHit
+from mcpax.tui.widgets.search_result_table import SearchResultTable
+
+
+def create_test_search_hit(
+    slug: str,
+    title: str,
+    project_type: ProjectType = ProjectType.MOD,
+    downloads: int = 1000,
+    description: str = "Test description",
+) -> SearchHit:
+    """Create a test SearchHit instance."""
+    return SearchHit(
+        slug=slug,
+        title=title,
+        description=description,
+        project_type=project_type,
+        downloads=downloads,
+        icon_url=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_initialization() -> None:
+    """Test SearchResultTable initialization."""
+    table = SearchResultTable()
+    assert table is not None
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_empty_results() -> None:
+    """Test SearchResultTable with empty results."""
+
+    class TestApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield SearchResultTable()
+
+    app = TestApp()
+    async with app.run_test():
+        table = app.query_one(SearchResultTable)
+        table.load_results([])
+
+        assert table.results == []
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_load_results() -> None:
+    """Test loading search results into the table."""
+
+    class TestApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield SearchResultTable()
+
+    results = [
+        create_test_search_hit("fabric-api", "Fabric API", ProjectType.MOD, 5000000),
+        create_test_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+        create_test_search_hit("iris", "Iris Shaders", ProjectType.SHADER, 2000000),
+    ]
+
+    app = TestApp()
+    async with app.run_test():
+        table = app.query_one(SearchResultTable)
+        table.load_results(results)
+
+        assert table.results == results
+        assert len(table.results) == 3
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_selected_result() -> None:
+    """Test selected_result property returns the first row by default."""
+
+    class TestApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield SearchResultTable()
+
+    results = [
+        create_test_search_hit("fabric-api", "Fabric API", ProjectType.MOD),
+        create_test_search_hit("sodium", "Sodium", ProjectType.MOD),
+    ]
+
+    app = TestApp()
+    async with app.run_test():
+        table = app.query_one(SearchResultTable)
+        table.load_results(results)
+
+        # By default, DataTable has cursor at first row
+        selected = table.selected_result
+        assert selected is not None
+        assert selected.slug == "fabric-api"
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_in_app() -> None:
+    """Test SearchResultTable integration in a minimal app."""
+
+    class TestApp(App[None]):
+        """Minimal app for testing SearchResultTable."""
+
+        def compose(self) -> ComposeResult:
+            yield SearchResultTable()
+
+    app = TestApp()
+    async with app.run_test():
+        # Check that SearchResultTable is rendered
+        table = app.query_one(SearchResultTable)
+        assert table is not None
+
+
+@pytest.mark.asyncio
+async def test_search_result_table_format_downloads() -> None:
+    """Test download count formatting (e.g., 1.2M, 500K)."""
+
+    class TestApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield SearchResultTable()
+
+    results = [
+        create_test_search_hit("project1", "Project 1", downloads=1234567),  # 1.2M
+        create_test_search_hit("project2", "Project 2", downloads=500000),  # 500.0K
+        create_test_search_hit("project3", "Project 3", downloads=999),  # 999
+    ]
+
+    app = TestApp()
+    async with app.run_test():
+        table = app.query_one(SearchResultTable)
+        table.load_results(results)
+
+        # Verify the table was populated and downloads are formatted
+        assert len(table.results) == 3
+        # Column index 3 is downloads
+        assert table.get_cell_at((0, 3)) == "1.2M"
+        assert table.get_cell_at((1, 3)) == "500.0K"
+        assert table.get_cell_at((2, 3)) == "999"


### PR DESCRIPTION
## 概要

TUI に Modrinth プロジェクト検索結果を表示する SearchScreen を実装しました。

## 関連 Issue

Closes #66

## 変更種別

- [x] 新機能(feat)
- [ ] バグ修正(fix)
- [ ] ドキュメント(docs)
- [ ] リファクタリング(refactor)
- [ ] テスト(test)
- [ ] その他(chore)

## 変更内容

### 新規実装
- **SearchScreen** (`src/mcpax/tui/screens/search.py`)
  - Modrinth API を使用してプロジェクト検索を実行
  - 検索結果を SearchResultTable に表示
  - `a` キーで選択したプロジェクトを projects.toml に追加
  - `Esc` キーで画面を閉じて MainScreen に戻る
  - プロジェクトタイプによるファセットフィルタリングに対応

- **SearchResultTable** ウィジェット (`src/mcpax/tui/widgets/search_result_table.py`)
  - 検索結果を DataTable で表示
  - Slug、Title、Type、Downloads の列を表示
  - ダウンロード数を読みやすい形式でフォーマット (例: 1.2M, 500.0K)
  - カーソルで選択した行を取得する API を提供

### 既存機能の変更
- **MainScreen** (`src/mcpax/tui/screens/main.py`)
  - SearchInput からの検索リクエストで SearchScreen に遷移
  - SearchScreen でプロジェクト追加後、自動的にプロジェクト一覧を更新

- **SearchInput** ウィジェット (`src/mcpax/tui/widgets/search_input.py`)
  - デバウンス機能を削除
  - Enter キー押下時のみ検索を実行するように変更
  - Select による type filter 変更時の自動検索を削除

- **スタイルシート** (`src/mcpax/tui/styles/app.tcss`)
  - SearchScreen および SearchResultTable のスタイル定義を追加

### テスト
- SearchScreen の包括的な単体テスト (`tests/unit/tui/screens/test_search.py`)
  - 初期化とプロパティ
  - キーバインディング (Esc, a)
  - 検索実行とプロジェクトタイプフィルタ
  - プロジェクト追加機能
  - 重複チェックとエラーハンドリング

- SearchResultTable の単体テスト (`tests/unit/tui/widgets/test_search_result_table.py`)
  - 初期化、結果の読み込み、選択機能
  - ダウンロード数のフォーマット

- MainScreen のテスト更新 (`tests/unit/tui/screens/test_main.py`)
  - SearchScreen への遷移を検証

- SearchInput のテスト更新 (`tests/unit/tui/widgets/test_search_input.py`)
  - デバウンス関連のテストを削除
  - Enter キー押下時の動作を検証

## テスト

- `uv run pytest tests/unit/tui/screens/test_search.py` - 全テストパス
- `uv run pytest tests/unit/tui/widgets/test_search_result_table.py` - 全テストパス
- `uv run pytest tests/unit/tui/screens/test_main.py` - 全テストパス
- `uv run pytest tests/unit/tui/widgets/test_search_input.py` - 全テストパス
- `uv run pytest` - 全体のテストスイートでエラーなし
- TUI アプリケーションでの手動動作確認
  - 検索クエリ入力と SearchScreen への遷移
  - 検索結果の表示と選択
  - プロジェクトの追加と projects.toml への保存
  - Esc キーでの画面クローズ

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

<!-- 実際の SearchScreen の動作スクリーンショットがあれば追加してください -->

## 補足情報

### 設計の意図

**SearchInput の動作変更**
- 当初はデバウンス機能を実装していましたが、UX の観点から Enter
キー押下時のみ検索を実行する仕様に変更しました
- これにより、ユーザーが意図的に検索を実行するタイミングを制御できます

**SearchScreen の責務**
- 検索実行と結果表示に特化
- projects.toml への追加機能を含む（`mcpax add` コマンドの TUI 版）
- プロジェクト追加後は MainScreen に制御を戻し、一覧の更新を MainScreen に委譲

**エラーハンドリング**
- 設定ファイルの読み込みエラー（ConfigValidationError）を適切に処理
- 重複プロジェクトの追加を防止し、ユーザーにフィードバック