### PR TITLE
feat(tui): Implement SettingsScreen for editing config.toml

### DIFF
--- a/src/mcpax/tui/screens/__init__.py
+++ b/src/mcpax/tui/screens/__init__.py
@@ -4,5 +4,12 @@ from .detail import ProjectDetailScreen
 from .install import InstallScreen
 from .main import MainScreen
 from .search import SearchScreen
+from .settings import SettingsScreen
 
-__all__ = ["MainScreen", "ProjectDetailScreen", "SearchScreen", "InstallScreen"]
+__all__ = [
+    "MainScreen",
+    "ProjectDetailScreen",
+    "SearchScreen",
+    "InstallScreen",
+    "SettingsScreen",
+]

--- a/src/mcpax/tui/screens/main.py
+++ b/src/mcpax/tui/screens/main.py
@@ -8,7 +8,7 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer
 from textual.worker import Worker, WorkerState
 
-from mcpax.core.config import ConfigValidationError, load_projects
+from mcpax.core.config import ConfigValidationError, load_config, load_projects
 from mcpax.core.manager import ProjectManager
 from mcpax.core.models import (
     AppConfig,
@@ -21,6 +21,7 @@ from mcpax.core.models import (
 from mcpax.tui.screens.detail import ProjectDetailScreen
 from mcpax.tui.screens.install import InstallScreen
 from mcpax.tui.screens.search import SearchScreen
+from mcpax.tui.screens.settings import SettingsScreen
 from mcpax.tui.widgets import ProjectTable, SearchInput, StatusBar
 
 
@@ -31,6 +32,7 @@ class MainScreen(Screen[None]):
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh"),
         Binding("i", "install", "Install All"),
+        Binding("s", "settings", "Settings"),
         Binding("enter", "view_detail", "View Detail"),
     ]
 
@@ -199,3 +201,29 @@ class MainScreen(Screen[None]):
         """
         if added:
             self._load_and_check_updates()
+
+    def action_settings(self) -> None:
+        """Open settings screen."""
+        self.app.push_screen(
+            SettingsScreen(),
+            callback=self._on_settings_dismissed,
+        )
+
+    def _on_settings_dismissed(self, changed: bool | None) -> None:
+        """Handle settings screen dismissal.
+
+        Args:
+            changed: True if settings were changed, False or None otherwise
+        """
+        if changed:
+            # Reload config
+            try:
+                self._config = load_config()
+                # Update StatusBar
+                status_bar = self.query_one(StatusBar)
+                status_bar.update_config(self._config)
+                # Reload projects
+                self._load_and_check_updates()
+            except Exception as e:
+                logging.exception("Error reloading config after settings change")
+                self.notify(f"Error reloading config: {e}", severity="error")

--- a/src/mcpax/tui/screens/settings.py
+++ b/src/mcpax/tui/screens/settings.py
@@ -1,0 +1,341 @@
+"""Settings screen for editing config.toml."""
+
+import logging
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, DataTable, Footer, Input, Select, Static
+
+from mcpax.core.config import (
+    get_all_config_values,
+    get_default_config_path,
+    set_config_value,
+)
+from mcpax.core.models import Loader
+
+# Section -> keys mapping for display order
+SETTINGS_SECTIONS: dict[str, list[str]] = {
+    "Minecraft": [
+        "minecraft.version",
+        "minecraft.mod_loader",
+        "minecraft.shader_loader",
+    ],
+    "Paths": [
+        "paths.minecraft_dir",
+        "paths.mods_dir",
+        "paths.shaders_dir",
+        "paths.resourcepacks_dir",
+    ],
+    "Download": [
+        "download.max_concurrent",
+        "download.verify_hash",
+    ],
+}
+
+# Key -> display label mapping
+FIELD_LABELS: dict[str, str] = {
+    "minecraft.version": "Minecraft Version",
+    "minecraft.mod_loader": "Mod Loader",
+    "minecraft.shader_loader": "Shader Loader",
+    "paths.minecraft_dir": "Minecraft Directory",
+    "paths.mods_dir": "Mods Directory",
+    "paths.shaders_dir": "Shaders Directory",
+    "paths.resourcepacks_dir": "Resource Packs Directory",
+    "download.max_concurrent": "Max Concurrent Downloads",
+    "download.verify_hash": "Verify Hash",
+}
+
+# Fields that should use Select widget with their choices
+SELECT_FIELDS: dict[str, list[tuple[str, str]]] = {
+    "minecraft.mod_loader": [
+        (Loader.FABRIC.value, "Fabric"),
+        (Loader.FORGE.value, "Forge"),
+        (Loader.NEOFORGE.value, "NeoForge"),
+        (Loader.QUILT.value, "Quilt"),
+    ],
+    "minecraft.shader_loader": [
+        ("", "None"),
+        (Loader.IRIS.value, "Iris"),
+        (Loader.OPTIFINE.value, "OptiFine"),
+    ],
+}
+
+# Fields that are boolean
+BOOLEAN_FIELDS: set[str] = {
+    "download.verify_hash",
+}
+
+
+class SettingsScreen(Screen[bool]):
+    """Settings screen for editing config.toml.
+
+    Returns:
+        True if settings were changed, False otherwise
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Back"),
+        Binding("enter", "edit_setting", "Edit"),
+    ]
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize SettingsScreen.
+
+        Args:
+            config_path: Path to config.toml (defaults to standard config path)
+        """
+        super().__init__()
+        self._config_path = config_path
+        self._changed = False
+        self._values: dict[str, str | int | bool | None] = {}
+        self._ordered_keys: list[str] = []
+        # Build reverse map: key -> section name for O(1) lookup
+        self._key_to_section: dict[str, str] = {
+            key: section
+            for section, keys in SETTINGS_SECTIONS.items()
+            for key in keys
+        }
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets.
+
+        Yields:
+            Header, DataTable, Footer
+        """
+        yield Static("Settings", id="settings-header")
+        table = DataTable(id="settings-table", cursor_type="row")
+        table.add_columns("Section", "Setting", "Value")
+        yield table
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Load settings when screen is mounted."""
+        self._load_settings()
+        # Focus the table so cursor is visible and keyboard works
+        table = self.query_one("#settings-table", DataTable)
+        table.focus()
+
+    def _load_settings(self) -> None:
+        """Load settings from config file and populate table."""
+        # Get config path
+        config_path = self._config_path or get_default_config_path()
+
+        # Try to load all config values
+        try:
+            self._values = get_all_config_values(config_path)
+        except FileNotFoundError:
+            # If config file doesn't exist, initialize with None values
+            from mcpax.core.config import CONFIG_KEY_MAP
+
+            self._values = {key: None for key in CONFIG_KEY_MAP}
+
+        # Build ordered list of keys from SETTINGS_SECTIONS
+        self._ordered_keys = []
+        for keys in SETTINGS_SECTIONS.values():
+            self._ordered_keys.extend(keys)
+
+        # Populate table
+        table = self.query_one("#settings-table", DataTable)
+        table.clear()
+
+        current_section = ""
+        for key in self._ordered_keys:
+            # Get section name from reverse map (O(1) lookup)
+            section_name = self._key_to_section.get(key, "")
+
+            # Only show section name on first occurrence
+            display_section = section_name if section_name != current_section else ""
+            current_section = section_name
+
+            # Get display label
+            label = FIELD_LABELS[key]
+
+            # Format value
+            value = self._values.get(key)
+            if value is None:
+                display_value = "(not set)"
+            elif isinstance(value, bool):
+                display_value = str(value)
+            else:
+                display_value = str(value)
+
+            # Add row
+            table.add_row(display_section, label, display_value)
+
+    def action_cancel(self) -> None:
+        """Cancel and return to main screen."""
+        self.dismiss(self._changed)
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Handle row selection (Enter key or click) in the data table.
+
+        Args:
+            event: Row selected event
+        """
+        self.action_edit_setting()
+
+    def action_edit_setting(self) -> None:
+        """Edit the selected setting."""
+        table = self.query_one("#settings-table", DataTable)
+
+        # Get cursor position
+        if table.cursor_coordinate is None:
+            return
+
+        row_index = table.cursor_coordinate.row
+
+        # Get the key for this row
+        if row_index >= len(self._ordered_keys):
+            return
+
+        key = self._ordered_keys[row_index]
+        label = FIELD_LABELS[key]
+
+        # Get current value
+        value = self._values.get(key)
+        if value is None:
+            current_value = ""
+        elif isinstance(value, bool):
+            current_value = str(value)
+        else:
+            current_value = str(value)
+
+        # Push the edit modal
+        self.app.push_screen(
+            EditSettingModal(key=key, label=label, current_value=current_value),
+            callback=self._on_edit_dismissed,
+        )
+
+    def _on_edit_dismissed(self, new_value: str | None) -> None:
+        """Handle edit modal dismissal.
+
+        Args:
+            new_value: New value from modal, or None if cancelled
+        """
+        if new_value is None:
+            # Cancelled
+            return
+
+        # Get current cursor position to determine which key was edited
+        table = self.query_one("#settings-table", DataTable)
+        if table.cursor_coordinate is None:
+            return
+
+        row_index = table.cursor_coordinate.row
+        if row_index >= len(self._ordered_keys):
+            return
+
+        key = self._ordered_keys[row_index]
+
+        # Save the value
+        config_path = self._config_path or get_default_config_path()
+        try:
+            set_config_value(key, new_value, config_path)
+            self._changed = True
+            # Reload settings to reflect the change
+            self._load_settings()
+        except (ValueError, FileNotFoundError) as exc:
+            logging.exception("Failed to save setting %s=%s", key, new_value)
+            self.notify(f"Failed to save setting: {exc}", severity="error")
+
+
+class EditSettingModal(ModalScreen[str | None]):
+    """Modal screen for editing a single setting.
+
+    Returns:
+        New value as string, or None if cancelled
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, key: str, label: str, current_value: str) -> None:
+        """Initialize EditSettingModal.
+
+        Args:
+            key: Config key (e.g., "minecraft.version")
+            label: Display label for the setting
+            current_value: Current value as string
+        """
+        super().__init__()
+        self._key = key
+        self._label = label
+        self._current_value = current_value
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets.
+
+        Yields:
+            Container with input field and buttons
+        """
+        with Container(id="edit-setting-container"):
+            yield Static(f"Edit {self._label}", id="edit-setting-header")
+
+            # Determine which widget to use
+            if self._key in SELECT_FIELDS:
+                # Use Select widget
+                choices = SELECT_FIELDS[self._key]
+                # Convert (value, label) to (prompt/label, value) for Select widget
+                # Textual Select expects (prompt, value) tuples
+                select_options = [(label, value) for value, label in choices]
+                # Use current value (enum value, not label)
+                initial = self._current_value
+                yield Select(
+                    select_options, value=initial, id="setting-input", allow_blank=False
+                )
+            elif self._key in BOOLEAN_FIELDS:
+                # Use Select widget for boolean
+                select_options = [("True", "True"), ("False", "False")]
+                yield Select(
+                    select_options,
+                    value=self._current_value,
+                    id="setting-input",
+                    allow_blank=False,
+                )
+            else:
+                # Use Input widget
+                yield Input(value=self._current_value, id="setting-input")
+
+            # Buttons
+            with Horizontal(id="button-row"):
+                yield Button("Save", variant="primary", id="save-button")
+                yield Button("Cancel", id="cancel-button")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button press.
+
+        Args:
+            event: Button press event
+        """
+        if event.button.id == "save-button":
+            self._save()
+        elif event.button.id == "cancel-button":
+            self.dismiss(None)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle Enter key in Input widget.
+
+        Args:
+            event: Input submitted event
+        """
+        self._save()
+
+    def _save(self) -> None:
+        """Save the new value and dismiss."""
+        # Get the new value from the input widget
+        widget = self.query_one("#setting-input")
+        if isinstance(widget, Select):
+            new_value = str(widget.value)
+        else:
+            assert isinstance(widget, Input)
+            new_value = widget.value
+
+        self.dismiss(new_value)
+
+    def action_cancel(self) -> None:
+        """Cancel and dismiss."""
+        self.dismiss(None)

--- a/src/mcpax/tui/styles/app.tcss
+++ b/src/mcpax/tui/styles/app.tcss
@@ -358,6 +358,65 @@ InstallScreen > Footer {
 }
 
 /* ============================================================================
+ * SettingsScreen
+ * ============================================================================ */
+
+SettingsScreen {
+    layout: vertical;
+}
+
+#settings-header {
+    dock: top;
+    height: auto;
+    background: $surface;
+    color: $primary;
+    text-style: bold;
+    padding: 1;
+}
+
+#settings-table {
+    height: 1fr;
+    background: $surface;
+    border: solid $border;
+}
+
+SettingsScreen > Footer {
+    dock: bottom;
+}
+
+/* ============================================================================
+ * EditSettingModal
+ * ============================================================================ */
+
+EditSettingModal {
+    align: center middle;
+}
+
+#edit-setting-container {
+    width: 70;
+    height: auto;
+    background: $surface-elevated;
+    border: thick $primary;
+    padding: 1 2;
+}
+
+#edit-setting-header {
+    text-style: bold;
+    color: $primary;
+    margin-bottom: 1;
+}
+
+#setting-input {
+    margin-bottom: 1;
+}
+
+#button-row {
+    layout: horizontal;
+    height: auto;
+    align: center middle;
+}
+
+/* ============================================================================
  * Future Widget Placeholders (commented out for now)
  * ============================================================================ */
 

--- a/tests/unit/tui/screens/test_main.py
+++ b/tests/unit/tui/screens/test_main.py
@@ -476,3 +476,101 @@ async def test_main_screen_install_action_no_updates() -> None:
 
             # Verify we're still on MainScreen (no InstallScreen pushed)
             assert isinstance(app.screen, MainScreen)
+
+
+@pytest.mark.asyncio
+async def test_main_screen_has_settings_binding() -> None:
+    """Test that MainScreen has settings key binding."""
+    screen = MainScreen(config=create_test_config())
+    binding_keys = [b.key for b in screen.BINDINGS]
+    assert "s" in binding_keys
+
+
+@pytest.mark.asyncio
+async def test_main_screen_action_settings_opens_screen() -> None:
+    """Test that action_settings opens SettingsScreen."""
+    from unittest.mock import MagicMock, patch
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(MainScreen(config=create_test_config()))
+
+    # Mock load_projects to return empty list
+    with (
+        patch("mcpax.tui.screens.main.load_projects") as mock_load,
+        patch("mcpax.tui.screens.main.ProjectManager") as mock_manager_class,
+    ):
+        mock_load.return_value = []
+        mock_manager = AsyncMock()
+        mock_manager.check_updates = AsyncMock(return_value=[])
+        mock_manager_class.return_value.__aenter__.return_value = mock_manager
+        mock_manager_class.return_value.__aexit__.return_value = AsyncMock()
+
+        app = TestApp()
+        async with app.run_test():
+            # Wait for initial load
+            await app.workers.wait_for_complete()
+
+            screen = app.screen
+            assert isinstance(screen, MainScreen)
+
+            # Mock push_screen to verify it's called
+            app.push_screen = MagicMock()  # type: ignore
+
+            # Call action_settings directly
+            screen.action_settings()
+
+            # Verify push_screen was called
+            assert app.push_screen.called
+            # Verify first argument is SettingsScreen instance
+            from mcpax.tui.screens.settings import SettingsScreen
+
+            args, kwargs = app.push_screen.call_args
+            assert isinstance(args[0], SettingsScreen)
+
+
+@pytest.mark.asyncio
+async def test_main_screen_on_settings_dismissed_reloads_config() -> None:
+    """Test that config is reloaded when settings are changed."""
+    from unittest.mock import patch
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(MainScreen(config=create_test_config()))
+
+    # Mock load_projects to return empty list
+    with (
+        patch("mcpax.tui.screens.main.load_projects") as mock_load,
+        patch("mcpax.tui.screens.main.ProjectManager") as mock_manager_class,
+        patch("mcpax.tui.screens.main.load_config") as mock_load_config,
+    ):
+        mock_load.return_value = []
+        mock_manager = AsyncMock()
+        mock_manager.check_updates = AsyncMock(return_value=[])
+        mock_manager_class.return_value.__aenter__.return_value = mock_manager
+        mock_manager_class.return_value.__aexit__.return_value = AsyncMock()
+
+        # Create a new config for reload
+        new_config = AppConfig(
+            minecraft_version="1.22.0",
+            mod_loader=Loader.FABRIC,
+            minecraft_dir=Path("/tmp/.minecraft"),
+        )
+        mock_load_config.return_value = new_config
+
+        app = TestApp()
+        async with app.run_test():
+            # Wait for initial load
+            await app.workers.wait_for_complete()
+
+            screen = app.screen
+            assert isinstance(screen, MainScreen)
+
+            # Call _on_settings_dismissed with True (changed)
+            screen._on_settings_dismissed(True)
+
+            # Verify load_config was called
+            mock_load_config.assert_called_once()
+
+            # Verify config was updated
+            assert screen._config == new_config

--- a/tests/unit/tui/screens/test_settings.py
+++ b/tests/unit/tui/screens/test_settings.py
@@ -1,0 +1,618 @@
+"""Tests for SettingsScreen and EditSettingModal."""
+
+from pathlib import Path
+
+import pytest
+from textual.app import App
+
+from mcpax.core.config import CONFIG_KEY_MAP
+
+
+class TestSettingsConstants:
+    """Test constants used in settings screen."""
+
+    def test_settings_sections_covers_all_config_keys(self):
+        """SETTINGS_SECTIONS should cover all CONFIG_KEY_MAP keys."""
+        from mcpax.tui.screens.settings import SETTINGS_SECTIONS
+
+        # Flatten all keys from SETTINGS_SECTIONS
+        all_keys = []
+        for keys in SETTINGS_SECTIONS.values():
+            all_keys.extend(keys)
+
+        # Check all CONFIG_KEY_MAP keys are present
+        config_keys = set(CONFIG_KEY_MAP.keys())
+        section_keys = set(all_keys)
+
+        assert config_keys == section_keys, (
+            f"Missing keys: {config_keys - section_keys}, "
+            f"Extra keys: {section_keys - config_keys}"
+        )
+
+    def test_field_labels_covers_all_config_keys(self):
+        """FIELD_LABELS should have labels for all CONFIG_KEY_MAP keys."""
+        from mcpax.tui.screens.settings import FIELD_LABELS
+
+        config_keys = set(CONFIG_KEY_MAP.keys())
+        label_keys = set(FIELD_LABELS.keys())
+
+        assert config_keys == label_keys, (
+            f"Missing keys: {config_keys - label_keys}, "
+            f"Extra keys: {label_keys - config_keys}"
+        )
+
+    def test_select_fields_has_mod_loader_and_shader_loader(self):
+        """SELECT_FIELDS should include mod_loader and shader_loader."""
+        from mcpax.tui.screens.settings import SELECT_FIELDS
+
+        assert "minecraft.mod_loader" in SELECT_FIELDS
+        assert "minecraft.shader_loader" in SELECT_FIELDS
+
+        # Check that choices are available
+        assert len(SELECT_FIELDS["minecraft.mod_loader"]) > 0
+        assert len(SELECT_FIELDS["minecraft.shader_loader"]) > 0
+
+    def test_boolean_fields_has_verify_hash(self):
+        """BOOLEAN_FIELDS should include verify_hash."""
+        from mcpax.tui.screens.settings import BOOLEAN_FIELDS
+
+        assert "download.verify_hash" in BOOLEAN_FIELDS
+
+
+class TestSettingsScreenStructure:
+    """Test SettingsScreen basic structure."""
+
+    @pytest.mark.asyncio
+    async def test_settings_screen_initialization(self, tmp_path: Path) -> None:
+        """Test SettingsScreen initialization."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        config_path = tmp_path / "config.toml"
+        screen = SettingsScreen(config_path=config_path)
+        assert screen is not None
+        assert screen._config_path == config_path
+
+    @pytest.mark.asyncio
+    async def test_settings_screen_initialization_default_path(self) -> None:
+        """Test SettingsScreen initialization with default path."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        screen = SettingsScreen()
+        assert screen is not None
+        assert screen._config_path is None
+
+    @pytest.mark.asyncio
+    async def test_settings_screen_compose(self, tmp_path: Path) -> None:
+        """Test SettingsScreen has required widgets."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                config_path = tmp_path / "config.toml"
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            assert screen is not None
+
+            # Check for DataTable
+            table = screen.query_one("#settings-table")
+            assert table is not None
+
+            # Check for Footer
+            from textual.widgets import Footer
+
+            footer = screen.query_one(Footer)
+            assert footer is not None
+
+    @pytest.mark.asyncio
+    async def test_settings_screen_bindings(self, tmp_path: Path) -> None:
+        """Test SettingsScreen has required key bindings."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        config_path = tmp_path / "config.toml"
+        screen = SettingsScreen(config_path=config_path)
+
+        # Check bindings
+        binding_keys = [b.key for b in screen.BINDINGS]
+        assert "escape" in binding_keys
+        assert "enter" in binding_keys
+
+
+class TestSettingsScreenLoading:
+    """Test settings loading functionality."""
+
+    @pytest.mark.asyncio
+    async def test_load_settings_displays_all_values(self, tmp_path: Path) -> None:
+        """Test that _load_settings displays all config values."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        # Create a test config file
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+shader_loader = "iris"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+
+[download]
+max_concurrent = 5
+verify_hash = true
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+
+            # Check that all 9 config keys are displayed
+            assert table.row_count == 9
+
+            # Verify some specific values by checking cell contents
+            # Get the first row (minecraft.version)
+            row_key = list(table.rows)[0]
+            first_row = table.get_row(row_key)
+            # Check value column (index 2)
+            assert "1.21.4" in str(first_row[2])
+
+    @pytest.mark.asyncio
+    async def test_load_settings_handles_missing_file(self, tmp_path: Path) -> None:
+        """Test that _load_settings handles missing config file."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        config_path = tmp_path / "nonexistent.toml"
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+
+            # Table should still be populated with "(not set)" values
+            assert table.row_count == 9
+
+    @pytest.mark.asyncio
+    async def test_load_settings_displays_not_set_for_missing_values(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that missing values are displayed as '(not set)'."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        # Create minimal config
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+
+            # Check that shader_loader shows "(not set)"
+            # Shader loader is the 3rd setting (index 2)
+            row_keys = list(table.rows)
+            shader_row = table.get_row(row_keys[2])
+            # Check label column (index 1) is "Shader Loader"
+            assert "Shader Loader" in str(shader_row[1])
+            # Check value column (index 2) is "(not set)"
+            assert "(not set)" in str(shader_row[2])
+
+
+class TestEditSettingModal:
+    """Test EditSettingModal widget selection."""
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_input_widget_for_string_fields(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that Input widget is used for string fields."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.version",
+                        label="Minecraft Version",
+                        current_value="1.21.4",
+                    )
+                )
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            # Should have an Input widget
+            from textual.widgets import Input
+
+            input_widget = screen.query_one(Input)
+            assert input_widget is not None
+            assert input_widget.value == "1.21.4"
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_select_widget_for_mod_loader(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that Select widget is used for mod_loader field."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.mod_loader",
+                        label="Mod Loader",
+                        current_value="fabric",
+                    )
+                )
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            # Should have a Select widget
+            from textual.widgets import Select
+
+            select_widget = screen.query_one(Select)
+            assert select_widget is not None
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_select_widget_for_boolean(self, tmp_path: Path) -> None:
+        """Test that Select widget is used for boolean fields."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="download.verify_hash",
+                        label="Verify Hash",
+                        current_value="True",
+                    )
+                )
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            # Should have a Select widget
+            from textual.widgets import Select
+
+            select_widget = screen.query_one(Select)
+            assert select_widget is not None
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_save_button_returns_new_value(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that Save button returns the new value."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        result = None
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.version",
+                        label="Minecraft Version",
+                        current_value="1.21.4",
+                    ),
+                    callback=self.handle_result,
+                )
+
+            def handle_result(self, value: str | None):
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            screen = app.screen
+            # Change the input value
+            from textual.widgets import Input
+
+            input_widget = screen.query_one(Input)
+            input_widget.value = "1.22.0"
+
+            # Click Save button
+            save_button = screen.query_one("#save-button")
+            await pilot.click(save_button)
+
+            # Wait a bit for the callback
+            await pilot.pause()
+
+            assert result == "1.22.0"
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_cancel_button_returns_none(self, tmp_path: Path) -> None:
+        """Test that Cancel button returns None."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        result = "UNSET"
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.version",
+                        label="Minecraft Version",
+                        current_value="1.21.4",
+                    ),
+                    callback=self.handle_result,
+                )
+
+            def handle_result(self, value: str | None):
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            screen = app.screen
+
+            # Click Cancel button
+            cancel_button = screen.query_one("#cancel-button")
+            await pilot.click(cancel_button)
+
+            # Wait a bit for the callback
+            await pilot.pause()
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_escape_key_cancels(self, tmp_path: Path) -> None:
+        """Test that Escape key cancels the modal."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        result = "UNSET"
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.version",
+                        label="Minecraft Version",
+                        current_value="1.21.4",
+                    ),
+                    callback=self.handle_result,
+                )
+
+            def handle_result(self, value: str | None):
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Press Escape
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_edit_modal_select_returns_enum_value_not_label(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that Select widget returns enum value, not human label."""
+        from mcpax.tui.screens.settings import EditSettingModal
+
+        result = None
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(
+                    EditSettingModal(
+                        key="minecraft.mod_loader",
+                        label="Mod Loader",
+                        current_value="fabric",
+                    ),
+                    callback=self.handle_result,
+                )
+
+            def handle_result(self, value: str | None):
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            screen = app.screen
+
+            # Get the Select widget
+            from textual.widgets import Select
+
+            select_widget = screen.query_one(Select)
+
+            # Change selection to "forge" (enum value)
+            select_widget.value = "forge"
+
+            # Click Save button
+            save_button = screen.query_one("#save-button")
+            await pilot.click(save_button)
+            await pilot.pause()
+
+            # Verify the result is the enum value "forge", not label "Forge"
+            assert result == "forge"
+            assert result != "Forge"
+
+
+class TestSettingsEditing:
+    """Test settings editing flow."""
+
+    @pytest.mark.asyncio
+    async def test_on_edit_dismissed_saves_value(self, tmp_path: Path) -> None:
+        """Test that _on_edit_dismissed saves the new value."""
+        from unittest.mock import patch
+
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        # Create a test config file
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+
+[download]
+max_concurrent = 5
+verify_hash = true
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+
+            # Set cursor to first row
+            table.cursor_coordinate = (0, 0)
+
+            # Mock set_config_value
+            with patch("mcpax.tui.screens.settings.set_config_value") as mock_set:
+                # Call _on_edit_dismissed directly with a new value
+                screen._on_edit_dismissed("1.22.0")
+
+                # Verify set_config_value was called
+                mock_set.assert_called_once_with(
+                    "minecraft.version", "1.22.0", config_path
+                )
+
+                # Verify _changed flag is True
+                assert screen._changed is True
+
+    @pytest.mark.asyncio
+    async def test_on_edit_dismissed_handles_save_error(self, tmp_path: Path) -> None:
+        """Test that save errors are handled gracefully."""
+        from unittest.mock import patch
+
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        # Create a test config file
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+            table.cursor_coordinate = (0, 0)
+
+            # Mock set_config_value to raise an error
+            with patch(
+                "mcpax.tui.screens.settings.set_config_value",
+                side_effect=ValueError("Invalid value"),
+            ):
+                # Call _on_edit_dismissed with invalid value
+                screen._on_edit_dismissed("invalid")
+
+                # Should handle error gracefully
+                # _changed should still be False
+                assert screen._changed is False
+
+    @pytest.mark.asyncio
+    async def test_on_edit_dismissed_cancel_does_not_change_flag(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that canceling edit doesn't set _changed flag."""
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+
+            # Call _on_edit_dismissed with None (cancelled)
+            screen._on_edit_dismissed(None)
+
+            # _changed should still be False
+            assert screen._changed is False
+
+    @pytest.mark.asyncio
+    async def test_on_edit_dismissed_saves_enum_value_not_label(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that enum value (not human label) is saved for Select fields."""
+        from unittest.mock import patch
+
+        from mcpax.tui.screens.settings import SettingsScreen
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[minecraft]
+version = "1.21.4"
+mod_loader = "fabric"
+
+[paths]
+minecraft_dir = "/tmp/.minecraft"
+""")
+
+        class TestApp(App[None]):
+            def on_mount(self):
+                self.push_screen(SettingsScreen(config_path=config_path))
+
+        app = TestApp()
+        async with app.run_test():
+            screen = app.screen
+            table = screen.query_one("#settings-table")
+
+            # Set cursor to mod_loader row (index 1)
+            table.cursor_coordinate = (1, 0)
+
+            # Mock set_config_value to verify it receives enum value, not label
+            with patch("mcpax.tui.screens.settings.set_config_value") as mock_set:
+                # Simulate changing mod_loader to "forge" (enum value)
+                # NOT "Forge" (human label)
+                screen._on_edit_dismissed("forge")
+
+                # Verify set_config_value was called with enum value
+                mock_set.assert_called_once_with(
+                    "minecraft.mod_loader", "forge", config_path
+                )
+                # Ensure it's NOT called with human label "Forge"
+                assert mock_set.call_args[0][1] != "Forge"


### PR DESCRIPTION
## 概要

config.tomlの設定を表示・編集できる設定画面（SettingsScreen）を実装しました。メイン画面から "s"
キーで設定画面を開き、各設定項目を編集できます。

## 関連 Issue

Closes #69

## 変更種別

- [x] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

### 新規実装
- `src/mcpax/tui/screens/settings.py`
  - `SettingsScreen`: 設定一覧を表示する画面
    - config.tomlの全設定値をセクション別に表示（Minecraft/Paths/Download）
    - Enter キーで設定項目を編集
    - Escape キーでメイン画面に戻る
  - `EditSettingModal`: 個別設定を編集するモーダル
    - 文字列フィールドは Input ウィジェット
    - mod_loader/shader_loader は Select ウィジェット（ドロップダウン）
    - boolean フィールドは Select ウィジェット（True/False）

### 既存ファイルの変更
- `src/mcpax/tui/screens/main.py`
  - "s" キーバインディングを追加
  - `action_settings()`: SettingsScreenを開く
  - `_on_settings_dismissed()`: 設定変更時にconfigをリロードし、StatusBarとプロジェクト一覧を更新

- `src/mcpax/tui/screens/__init__.py`
  - `SettingsScreen` をエクスポート

- `src/mcpax/tui/styles/app.tcss`
  - SettingsScreen と EditSettingModal のスタイル定義

### テスト
- `tests/unit/tui/screens/test_settings.py`
  - 定数（SETTINGS_SECTIONS, FIELD_LABELS, SELECT_FIELDS, BOOLEAN_FIELDS）の網羅性テスト
  - SettingsScreen の初期化、構成、キーバインディングのテスト
  - 設定読み込みのテスト（正常系/ファイル不在/一部未設定）
  - EditSettingModal のウィジェット選択テスト（Input/Select）
  - 設定編集フローのテスト（保存/キャンセル/エラーハンドリング）
  - enum値と表示ラベルの正しい扱いのテスト

- `tests/unit/tui/screens/test_main.py`
  - MainScreen の設定関連テストを追加
    - "s" キーバインディングの存在確認
    - `action_settings()` が SettingsScreen を開くことを確認
    - `_on_settings_dismissed()` が設定変更時に config をリロードすることを確認

## テスト

- 全てのユニットテストが通過することを確認
- 以下のテストケースをカバー：
  - 設定画面の表示と操作（Enter/Escape キー）
  - 各種ウィジェット（Input/Select）の適切な選択
  - 設定値の保存とリロード
  - エラーハンドリング（無効な値、ファイル不在）
  - MainScreenとの連携（設定変更後の再読み込み）

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

<!-- UI の変更があるため、スクリーンショットがあると望ましい -->

## 補足情報（任意）

- 設定画面は MainScreen から独立しており、他の画面からも再利用可能な設計
- 設定変更時のリロードロジックは MainScreen 側で実装しており、SettingsScreen
は変更フラグのみを返す責務分離
- enum値（例："fabric"）と表示ラベル（例："Fabric"）を正しく扱うため、Select
ウィジェットのオプション生成に注意
- エラーメッセージのUI表示は TODO
として残されており、今後の改善ポイント（src/mcpax/tui/screens/settings.py:238）