### PR TITLE
feat: implement version pinning in install/update logic

### DIFF
--- a/.claude/rules/project-structure.md
+++ b/.claude/rules/project-structure.md
@@ -45,6 +45,11 @@ slug = "fabric-api"
 [[projects]]
 slug = "sodium"
 
+# Version pinning (optional)
+[[projects]]
+slug = "iris"
+version = "1.7.0"
+
 [[projects]]
 slug = "complementary-unbound"  # shader
 ```
@@ -53,7 +58,7 @@ slug = "complementary-unbound"  # shader
 
 ```bash
 mcpax init                              # Initialize configuration files
-mcpax add <slug>                        # Add project
+mcpax add <slug> [--version VERSION]    # Add project (optionally pin version)
 mcpax remove <slug>                     # Remove project
 mcpax list [--type TYPE] [--json]       # List registered projects (includes install status/filters)
 mcpax search <query> [OPTIONS]          # Search Modrinth

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Minecraft の MOD / Modpack / Shader / Resource Pack を Modrinth API 経由で�
 - TOML 形式の設定ファイルでプロジェクトリストを管理
 - 指定した Minecraft バージョン・Loader に対応するプロジェクトを自動取得
 - プロジェクト種別（MOD / Shader / Resource Pack）に応じた適切なディレクトリ配置
+- バージョンピニング（特定バージョンで固定可能）
 - Modpack の検索機能（インストールは未対応）
 - ハッシュ検証による安全なダウンロード
 - 差分更新（変更があったプロジェクトのみダウンロード）
@@ -78,6 +79,12 @@ project_type = "mod"
 slug = "sodium"
 project_type = "mod"
 
+# バージョン固定（特定バージョンで維持したい場合）
+[[projects]]
+slug = "iris"
+project_type = "mod"
+version = "1.7.0"
+
 [[projects]]
 slug = "complementary-reimagined"
 project_type = "shader"
@@ -88,6 +95,9 @@ project_type = "shader"
 ```bash
 # slug がわかっている場合
 mcpax add sodium
+
+# 特定バージョンで固定したい場合
+mcpax add iris --version 1.7.0
 
 # slug がわからない場合は検索
 mcpax search shader

--- a/docs/05_conceptual_data_model.md
+++ b/docs/05_conceptual_data_model.md
@@ -62,7 +62,7 @@
 |------|-----|------|
 | slug | string | Modrinth のプロジェクト識別子（例: "sodium"） |
 | project_type | enum | プロジェクト種別: mod / shader / resourcepack |
-| version_pin | string? | バージョン固定（省略時は最新） |
+| version | string? | バージョン固定（省略時は最新の互換バージョン） |
 | channel | enum? | リリースチャネル: release / beta / alpha（省略時は release） |
 
 ### InstalledFile（インストール済みファイル）

--- a/docs/07_function_definition.md
+++ b/docs/07_function_definition.md
@@ -649,7 +649,18 @@ class UpdateCheckResult:
     latest_version: str | None
     latest_file: ProjectFile | None
     error: str | None
+    pinned: bool = False
 ```
+
+#### バージョンピニング対応
+
+`ProjectConfig.version` が設定されている場合、指定されたバージョンを使用する：
+
+1. 指定バージョンが存在し互換性がある → `latest_version` にピン留めバージョンをセット、`pinned=True`
+2. 指定バージョンが存在しない → `status=NOT_COMPATIBLE`、`error` にメッセージ、`pinned=True`
+3. 指定バージョンが存在するが非互換 → `status=NOT_COMPATIBLE`、`error` にメッセージ、`pinned=True`
+
+ピン留めされたプロジェクトは、常にピン留めバージョンと比較される。
 
 ---
 

--- a/docs/08_data_definition.md
+++ b/docs/08_data_definition.md
@@ -359,6 +359,8 @@ class UpdateCheckResult:
     current_file: InstalledFile | None
     latest_version: str | None
     latest_file: ProjectFile | None
+    error: str | None = None
+    pinned: bool = False
 ```
 
 #### 属性
@@ -369,8 +371,10 @@ class UpdateCheckResult:
 | status | InstallStatus | インストール状態 |
 | current_version | str \| None | 現在のバージョン |
 | current_file | InstalledFile \| None | 現在のファイル |
-| latest_version | str \| None | 最新バージョン |
-| latest_file | ProjectFile \| None | 最新ファイル |
+| latest_version | str \| None | 最新バージョン（ピン留め時はピン留めバージョン） |
+| latest_file | ProjectFile \| None | 最新ファイル（ピン留め時はピン留めバージョンのファイル） |
+| error | str \| None | エラーメッセージ（エラー時のみ） |
+| pinned | bool | バージョンがピン留めされているか |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpax"
-version = "0.9.0"
+version = "0.10.0"
 description = "Minecraft MOD/Shader/Resource Pack manager via Modrinth API"
 readme = "README.md"
 license = "MIT"

--- a/src/mcpax/__init__.py
+++ b/src/mcpax/__init__.py
@@ -1,3 +1,3 @@
 """mcpax - Minecraft MOD/Shader/Resource Pack manager via Modrinth API."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -901,7 +901,8 @@ def update(
                 current = result.current_version or "not installed"
                 latest = result.latest_version or "unknown"
                 arrow = f"{current} → {latest}"
-                console.print(f"  {result.slug:<20} {arrow}")
+                pinned_marker = " [pinned]" if result.pinned else ""
+                console.print(f"  {result.slug:<20} {arrow}{pinned_marker}")
             continue
         if kind == "up_to_date":
             slugs = ", ".join(r.slug for r in items)

--- a/src/mcpax/core/api.py
+++ b/src/mcpax/core/api.py
@@ -386,3 +386,22 @@ class ModrinthClient:
             versions, minecraft_version, loader, channel, project_type, shader_loader
         )
         return compatible[0] if compatible else None
+
+    def find_version_by_number(
+        self,
+        versions: list[ProjectVersion],
+        version_number: str,
+    ) -> ProjectVersion | None:
+        """Find a version by exact version number match.
+
+        Args:
+            versions: List of versions to search
+            version_number: Exact version number to find
+
+        Returns:
+            ProjectVersion with matching version_number or None
+        """
+        for version in versions:
+            if version.version_number == version_number:
+                return version
+        return None

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -23,6 +23,7 @@ from mcpax.core.models import (
     ProjectConfig,
     ProjectFile,
     ProjectType,
+    ProjectVersion,
     ReleaseChannel,
     StateFile,
     UpdateCheckResult,
@@ -369,14 +370,30 @@ class ProjectManager:
                 if installed.project_type == ProjectType.SHADER
                 else None
             )
-            latest = self._api_client.get_latest_compatible_version(
-                versions,
-                self._config.minecraft_version,
-                self._config.mod_loader,
-                channel=channel,
-                project_type=installed.project_type,
-                shader_loader=shader_loader,
-            )
+
+            # If version is pinned, use pinned logic
+            if project_config is not None and project_config.version is not None:
+                pinned_version, _error = self._get_pinned_compatible_version(
+                    versions,
+                    project_config.version,
+                    installed.project_type,
+                    channel,
+                )
+
+                if pinned_version is None:
+                    return InstallStatus.NOT_COMPATIBLE
+
+                latest = pinned_version
+            else:
+                # Non-pinned: use existing logic
+                latest = self._api_client.get_latest_compatible_version(
+                    versions,
+                    self._config.minecraft_version,
+                    self._config.mod_loader,
+                    channel=channel,
+                    project_type=installed.project_type,
+                    shader_loader=shader_loader,
+                )
 
             if latest is None:
                 return InstallStatus.NOT_COMPATIBLE
@@ -474,11 +491,18 @@ class ProjectManager:
             raise RuntimeError(msg)
 
         installed = await self.get_installed_file(project.slug)
-
         project_type = project.project_type
 
-        # Get latest compatible version
+        # Get all versions
         versions = await self._api_client.get_versions(project.slug)
+
+        # If version is pinned, use pinned logic
+        if project.version is not None:
+            return await self._resolve_pinned_version(
+                project, versions, installed, project_type
+            )
+
+        # Non-pinned: use existing logic
         shader_loader = (
             self._config.shader_loader if project_type == ProjectType.SHADER else None
         )
@@ -524,6 +548,131 @@ class ProjectManager:
             latest_version=latest.version_number,
             latest_version_id=latest.id,
             latest_file=primary_file,
+        )
+
+    def _get_pinned_compatible_version(
+        self,
+        versions: list[ProjectVersion],
+        version_number: str,
+        project_type: ProjectType,
+        channel: ReleaseChannel | None = None,
+    ) -> tuple[ProjectVersion | None, str | None]:
+        """Get pinned version and check compatibility.
+
+        Args:
+            versions: All available versions
+            version_number: Pinned version number
+            project_type: Project type
+            channel: Release channel filter
+
+        Returns:
+            Tuple of (pinned_version, error_message).
+            If successful, returns (version, None).
+            If failed, returns (None, error_message).
+        """
+        if self._api_client is None:
+            msg = "API client not initialized"
+            raise RuntimeError(msg)
+
+        # Find the pinned version
+        pinned_version = self._api_client.find_version_by_number(
+            versions, version_number
+        )
+
+        if pinned_version is None:
+            return None, f"Pinned version {version_number} not found"
+
+        # Check if the pinned version is compatible
+        shader_loader = (
+            self._config.shader_loader if project_type == ProjectType.SHADER else None
+        )
+        # Use default channel if not specified
+        release_channel = channel if channel is not None else ReleaseChannel.RELEASE
+        compatible_versions = self._api_client.filter_compatible_versions(
+            [pinned_version],
+            self._config.minecraft_version,
+            self._config.mod_loader,
+            release_channel,
+            project_type=project_type,
+            shader_loader=shader_loader,
+        )
+
+        if not compatible_versions:
+            return None, f"Pinned version {version_number} is not compatible"
+
+        return pinned_version, None
+
+    async def _resolve_pinned_version(
+        self,
+        project: ProjectConfig,
+        versions: list[ProjectVersion],
+        installed: InstalledFile | None,
+        project_type: ProjectType,
+    ) -> UpdateCheckResult:
+        """Resolve pinned version.
+
+        Args:
+            project: Project configuration with pinned version
+            versions: All available versions
+            installed: Currently installed file
+            project_type: Project type
+
+        Returns:
+            UpdateCheckResult with pinned=True
+        """
+        if self._api_client is None:
+            msg = "API client not initialized"
+            raise RuntimeError(msg)
+
+        # Ensure version is not None (should be guaranteed by caller)
+        version_number = project.version
+        if version_number is None:
+            msg = "_resolve_pinned_version called without pinned version"
+            raise RuntimeError(msg)
+
+        # Use helper method to get pinned compatible version
+        pinned_version, error = self._get_pinned_compatible_version(
+            versions, version_number, project_type, project.channel
+        )
+
+        if pinned_version is None:
+            # Version not found or not compatible
+            return UpdateCheckResult(
+                slug=project.slug,
+                project_type=project_type,
+                status=InstallStatus.NOT_COMPATIBLE,
+                current_version=installed.version_number if installed else None,
+                current_file=installed,
+                latest_version=None,
+                latest_version_id=None,
+                latest_file=None,
+                error=error,
+                pinned=True,
+            )
+
+        # Compatible pinned version found
+        primary_file = next(
+            (f for f in pinned_version.files if f.primary),
+            pinned_version.files[0] if pinned_version.files else None,
+        )
+
+        if installed is None:
+            status = InstallStatus.NOT_INSTALLED
+        elif self.needs_update(installed, primary_file):
+            status = InstallStatus.OUTDATED
+        else:
+            status = InstallStatus.INSTALLED
+
+        return UpdateCheckResult(
+            slug=project.slug,
+            project_type=project_type,
+            status=status,
+            current_version=installed.version_number if installed else None,
+            current_file=installed,
+            latest_version=pinned_version.version_number,
+            latest_version_id=pinned_version.id,
+            latest_file=primary_file,
+            pinned=True,
         )
 
     async def apply_updates(

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -177,6 +177,7 @@ class UpdateCheckResult(BaseModel):
     latest_version_id: str | None = None
     latest_file: ProjectFile | None
     error: str | None = None
+    pinned: bool = False
 
 
 class DownloadTask(BaseModel):

--- a/src/mcpax/tui/screens/__init__.py
+++ b/src/mcpax/tui/screens/__init__.py
@@ -5,6 +5,11 @@ from .install import InstallScreen
 from .main import MainScreen
 from .search import SearchScreen
 from .settings import SettingsScreen
+from .version_select import (
+    VERSION_SELECT_CANCELLED,
+    VERSION_SELECT_LATEST,
+    VersionSelectScreen,
+)
 
 __all__ = [
     "MainScreen",
@@ -12,4 +17,7 @@ __all__ = [
     "SearchScreen",
     "InstallScreen",
     "SettingsScreen",
+    "VersionSelectScreen",
+    "VERSION_SELECT_CANCELLED",
+    "VERSION_SELECT_LATEST",
 ]

--- a/src/mcpax/tui/screens/search.py
+++ b/src/mcpax/tui/screens/search.py
@@ -9,7 +9,12 @@ from textual.widgets import Footer, Static
 from textual.worker import Worker, WorkerState
 
 from mcpax.core.api import ModrinthClient
-from mcpax.core.config import ConfigValidationError, load_projects, save_projects
+from mcpax.core.config import (
+    ConfigValidationError,
+    load_config,
+    load_projects,
+    save_projects,
+)
 from mcpax.core.models import (
     ProjectConfig,
     ProjectType,
@@ -100,13 +105,54 @@ class SearchScreen(Screen[bool]):
             self.notify("No project selected", severity="warning")
             return
 
-        self._add_project_to_config(selected)
+        # Show version selection screen
+        self.run_worker(self._show_version_select(selected), exclusive=False)
 
-    def _add_project_to_config(self, hit: SearchHit) -> None:
+    async def _show_version_select(self, hit: SearchHit) -> None:
+        """Show version selection screen and add project.
+
+        Args:
+            hit: Selected search hit
+        """
+        from mcpax.tui.screens.version_select import (
+            VERSION_SELECT_CANCELLED,
+            VERSION_SELECT_LATEST,
+            VersionSelectScreen,
+        )
+
+        try:
+            # Load config to get minecraft version and mod loader
+            config = load_config()
+        except (FileNotFoundError, ConfigValidationError) as e:
+            self.notify(f"Failed to load config: {e}", severity="error")
+            return
+
+        # Push version selection screen
+        version_select_screen = VersionSelectScreen(
+            slug=hit.slug,
+            project_type=hit.project_type,
+            minecraft_version=config.minecraft_version,
+            mod_loader=config.mod_loader.value,
+        )
+
+        selected_version = await self.app.push_screen_wait(version_select_screen)
+
+        # Handle version selection result
+        if selected_version == VERSION_SELECT_CANCELLED:
+            return  # User cancelled, don't add project
+        elif selected_version == VERSION_SELECT_LATEST:
+            self._add_project_to_config(hit, version=None)  # No version pinning
+        else:
+            self._add_project_to_config(hit, version=selected_version)
+
+    def _add_project_to_config(
+        self, hit: SearchHit, version: str | None = None
+    ) -> None:
         """Add project to projects.toml.
 
         Args:
             hit: Selected search hit to add
+            version: Optional version to pin
         """
         try:
             projects = load_projects()
@@ -122,7 +168,15 @@ class SearchScreen(Screen[bool]):
             return
 
         # Add new project
-        projects.append(ProjectConfig(slug=hit.slug, project_type=hit.project_type))
+        projects.append(
+            ProjectConfig(slug=hit.slug, project_type=hit.project_type, version=version)
+        )
         save_projects(projects)
         self._added = True
-        self.notify(f"Added '{hit.slug}'", severity="information")
+
+        if version:
+            self.notify(
+                f"Added '{hit.slug}' (pinned to {version})", severity="information"
+            )
+        else:
+            self.notify(f"Added '{hit.slug}' (latest)", severity="information")

--- a/src/mcpax/tui/screens/version_select.py
+++ b/src/mcpax/tui/screens/version_select.py
@@ -1,0 +1,213 @@
+"""Version selection screen for pinning a specific version."""
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Label, Static
+from textual.worker import Worker, WorkerState
+
+from mcpax.core.api import ModrinthClient
+from mcpax.core.models import ProjectType, ProjectVersion
+
+# Version selection result constants
+VERSION_SELECT_CANCELLED: None = None
+VERSION_SELECT_LATEST: str = "__LATEST__"
+
+
+class VersionSelectScreen(Screen[str | None]):
+    """Screen for selecting a version to pin."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "select", "Select"),
+        Binding("l", "select_latest", "Latest (no pin)"),
+    ]
+
+    def __init__(
+        self,
+        slug: str,
+        project_type: ProjectType,
+        minecraft_version: str,
+        mod_loader: str,
+    ) -> None:
+        """Initialize VersionSelectScreen.
+
+        Args:
+            slug: Project slug
+            project_type: Project type
+            minecraft_version: Minecraft version for filtering
+            mod_loader: Mod loader for filtering
+        """
+        super().__init__()
+        self._slug = slug
+        self._project_type = project_type
+        self._minecraft_version = minecraft_version
+        self._mod_loader = mod_loader
+        self._versions: dict[str, ProjectVersion] = {}
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets.
+
+        Yields:
+            Screen widgets
+        """
+        yield Container(
+            Static(f"Select version for '{self._slug}'", id="version-header"),
+            Label(
+                "Press [b]Enter[/b] to pin selected version, "
+                "[b]L[/b] for latest (no pin), [b]Esc[/b] to cancel"
+            ),
+            Vertical(
+                DataTable(id="version-table", cursor_type="row"),
+                id="version-container",
+            ),
+            Footer(),
+        )
+
+    def on_mount(self) -> None:
+        """Fetch versions when screen is mounted."""
+        table = self.query_one(DataTable)
+        table.add_column("Version", key="version")
+        table.add_column("Type", key="type")
+        table.add_column("Loaders", key="loaders")
+        table.add_column("Game Versions", key="game_versions")
+        table.add_column("Date", key="date")
+
+        self.run_worker(self._fetch_versions(), exclusive=True)
+
+    async def _fetch_versions(self) -> list[ProjectVersion]:
+        """Fetch versions from Modrinth API.
+
+        Returns:
+            List of project versions
+        """
+        async with ModrinthClient() as client:
+            return await client.get_versions(self._slug)
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        """Handle worker state changes.
+
+        Args:
+            event: Worker state change event
+        """
+        if event.state == WorkerState.SUCCESS:
+            result = event.worker.result
+            if isinstance(result, list):
+                self._populate_table(result)
+        elif event.state == WorkerState.ERROR:
+            self.notify(
+                f"Failed to fetch versions: {event.worker.error}", severity="error"
+            )
+            self.dismiss(None)
+
+    def _populate_table(self, versions: list[ProjectVersion]) -> None:
+        """Populate table with versions.
+
+        Args:
+            versions: List of versions to display
+        """
+        table = self.query_one(DataTable)
+
+        if not versions:
+            self.notify("No versions found", severity="warning")
+            self.dismiss(None)
+            return
+
+        # Store versions mapping for later retrieval
+        self._versions = {version.id: version for version in versions}
+
+        # Filter compatible versions first for better UX
+        compatible = []
+        incompatible = []
+
+        for version in versions:
+            # Check if compatible with current Minecraft version
+            is_compatible = self._minecraft_version in version.game_versions
+
+            # For mods, also check loader compatibility
+            if self._project_type == ProjectType.MOD:
+                is_compatible = is_compatible and self._mod_loader in version.loaders
+
+            if is_compatible:
+                compatible.append(version)
+            else:
+                incompatible.append(version)
+
+        # Add compatible versions first (highlighted)
+        for version in compatible:
+            game_versions = ", ".join(version.game_versions[:3])
+            if len(version.game_versions) > 3:
+                game_versions += "..."
+
+            loaders = ", ".join(version.loaders)
+
+            table.add_row(
+                version.version_number,
+                version.version_type,
+                loaders,
+                game_versions,
+                version.date_published.strftime("%Y-%m-%d"),
+                key=version.id,
+            )
+
+        # Add incompatible versions (dimmed)
+        for version in incompatible:
+            game_versions = ", ".join(version.game_versions[:3])
+            if len(version.game_versions) > 3:
+                game_versions += "..."
+
+            loaders = ", ".join(version.loaders)
+
+            table.add_row(
+                f"[dim]{version.version_number}[/dim]",
+                f"[dim]{version.version_type}[/dim]",
+                f"[dim]{loaders}[/dim]",
+                f"[dim]{game_versions}[/dim]",
+                f"[dim]{version.date_published.strftime('%Y-%m-%d')}[/dim]",
+                key=version.id,
+            )
+
+        if compatible:
+            # Select first compatible version by default
+            table.move_cursor(row=0)
+
+    def action_cancel(self) -> None:
+        """Cancel version selection."""
+        self.dismiss(VERSION_SELECT_CANCELLED)
+
+    def action_select_latest(self) -> None:
+        """Select latest version (no pinning)."""
+        self.dismiss(VERSION_SELECT_LATEST)
+
+    def action_select(self) -> None:
+        """Select the currently highlighted version."""
+        table = self.query_one(DataTable)
+        if table.cursor_row is None:
+            self.notify("No version selected", severity="warning")
+            return
+
+        # Get the version ID from the row key
+        row_key = table.coordinate_to_cell_key(table.cursor_coordinate).row_key
+        if row_key:
+            self._dismiss_with_version_id(str(row_key.value))
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Handle row selection via Enter key on DataTable.
+
+        Args:
+            event: Row selection event
+        """
+        # Get the version ID from the row key
+        if event.row_key:
+            self._dismiss_with_version_id(str(event.row_key.value))
+
+    def _dismiss_with_version_id(self, version_id: str) -> None:
+        """Dismiss the screen with the version number for the given version ID.
+
+        Args:
+            version_id: Version ID to dismiss with
+        """
+        version = self._versions.get(version_id)
+        if version:
+            self.dismiss(version.version_number)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1071,3 +1071,65 @@ class TestGetLatestCompatibleVersion:
 
         # Assert
         assert result is None
+
+
+class TestFindVersionByNumber:
+    """Tests for ModrinthClient.find_version_by_number()."""
+
+    def test_returns_matching_version(self) -> None:
+        """Returns version with matching version_number."""
+        # Arrange
+        versions = [
+            _make_version("1.0.0"),
+            _make_version("1.1.0"),
+            _make_version("2.0.0"),
+        ]
+        client = ModrinthClient()
+
+        # Act
+        result = client.find_version_by_number(versions, "1.1.0")
+
+        # Assert
+        assert result is not None
+        assert result.version_number == "1.1.0"
+
+    def test_returns_none_when_not_found(self) -> None:
+        """Returns None when version_number is not found."""
+        # Arrange
+        versions = [
+            _make_version("1.0.0"),
+            _make_version("2.0.0"),
+        ]
+        client = ModrinthClient()
+
+        # Act
+        result = client.find_version_by_number(versions, "1.5.0")
+
+        # Assert
+        assert result is None
+
+    def test_exact_match_only(self) -> None:
+        """Returns None if version_number is not exact match."""
+        # Arrange
+        versions = [
+            _make_version("1.0.0"),
+        ]
+        client = ModrinthClient()
+
+        # Act
+        result = client.find_version_by_number(versions, "1.0")
+
+        # Assert
+        assert result is None
+
+    def test_returns_none_for_empty_list(self) -> None:
+        """Returns None when versions list is empty."""
+        # Arrange
+        versions: list[ProjectVersion] = []
+        client = ModrinthClient()
+
+        # Act
+        result = client.find_version_by_number(versions, "1.0.0")
+
+        # Assert
+        assert result is None

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -958,6 +958,169 @@ class TestGetInstallStatusWithChannel:
         assert result == InstallStatus.INSTALLED
 
 
+class TestGetInstallStatusPinning:
+    """Tests for get_install_status with version pinning."""
+
+    async def test_pinned_version_installed(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version installed -> INSTALLED."""
+        # Arrange
+        config = _make_config(tmp_path)
+        file_path = tmp_path / "mods" / "sodium.jar"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("content")
+
+        pinned_hash = "pinnedhash" * 20
+        installed = _make_installed_file(
+            "sodium",
+            file_path=file_path,
+            version_number="1.5.0",
+            sha512=pinned_hash,
+        )
+
+        manager_temp = ProjectManager(config)
+        state = StateFile(version=1, files={"sodium": installed})
+        await manager_temp._save_state(state)
+
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="pinned-id",
+                    version_number="1.5.0",
+                    version_type="release",
+                    sha512=pinned_hash,
+                ),
+                _make_version_payload(
+                    version_id="newer-id",
+                    version_number="2.0.0",
+                    version_type="release",
+                    sha512="newerhash" * 20,
+                ),
+            ],
+        )
+
+        project_config = ProjectConfig(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            version="1.5.0",
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            result = await manager.get_install_status(
+                "sodium",
+                project_config=project_config,
+            )
+
+        # Assert
+        assert result == InstallStatus.INSTALLED
+
+    async def test_pinned_version_outdated(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Different version installed than pinned -> OUTDATED."""
+        # Arrange
+        config = _make_config(tmp_path)
+        file_path = tmp_path / "mods" / "sodium.jar"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("content")
+
+        installed = _make_installed_file(
+            "sodium",
+            file_path=file_path,
+            version_number="1.0.0",
+            sha512="oldhash" * 20,
+        )
+
+        manager_temp = ProjectManager(config)
+        state = StateFile(version=1, files={"sodium": installed})
+        await manager_temp._save_state(state)
+
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="pinned-id",
+                    version_number="1.5.0",
+                    version_type="release",
+                    sha512="pinnedhash" * 20,
+                ),
+            ],
+        )
+
+        project_config = ProjectConfig(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            version="1.5.0",
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            result = await manager.get_install_status(
+                "sodium",
+                project_config=project_config,
+            )
+
+        # Assert
+        assert result == InstallStatus.OUTDATED
+
+    async def test_pinned_version_not_found(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version not found -> NOT_COMPATIBLE."""
+        # Arrange
+        config = _make_config(tmp_path)
+        file_path = tmp_path / "mods" / "sodium.jar"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("content")
+
+        installed = _make_installed_file(
+            "sodium",
+            file_path=file_path,
+            sha512="hash" * 20,
+        )
+
+        manager_temp = ProjectManager(config)
+        state = StateFile(version=1, files={"sodium": installed})
+        await manager_temp._save_state(state)
+
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="other-id",
+                    version_number="1.0.0",
+                    version_type="release",
+                    sha512="otherhash" * 20,
+                ),
+            ],
+        )
+
+        project_config = ProjectConfig(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            version="1.5.0",
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            result = await manager.get_install_status(
+                "sodium",
+                project_config=project_config,
+            )
+
+        # Assert
+        assert result == InstallStatus.NOT_COMPATIBLE
+
+
 class TestNeedsUpdate:
     """Tests for F-502: needs_update."""
 
@@ -1197,6 +1360,276 @@ class TestCheckUpdates:
 
         # Assert
         assert results == []
+
+
+class TestCheckUpdatesPinning:
+    """Tests for check_updates with version pinning."""
+
+    async def test_pinned_not_installed(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version, not installed -> NOT_INSTALLED, pinned=True."""
+        # Arrange
+        config = _make_config(tmp_path)
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="pinned-id",
+                    version_number="1.5.0",
+                    version_type="release",
+                    sha512="pinnedhash" * 20,
+                )
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                        version="1.5.0",
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.NOT_INSTALLED
+        assert results[0].pinned is True
+        assert results[0].latest_version == "1.5.0"
+        assert results[0].latest_version_id == "pinned-id"
+
+    async def test_pinned_same_version_installed(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version matches installed -> INSTALLED, pinned=True."""
+        # Arrange
+        config = _make_config(tmp_path)
+        file_path = tmp_path / "mods" / "sodium.jar"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("content")
+
+        pinned_hash = "pinnedhash" * 20
+        installed = _make_installed_file(
+            "sodium",
+            file_path=file_path,
+            version_number="1.5.0",
+            sha512=pinned_hash,
+        )
+        manager_temp = ProjectManager(config)
+        state = StateFile(version=1, files={"sodium": installed})
+        await manager_temp._save_state(state)
+
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="pinned-id",
+                    version_number="1.5.0",
+                    version_type="release",
+                    sha512=pinned_hash,
+                )
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                        version="1.5.0",
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.INSTALLED
+        assert results[0].pinned is True
+        assert results[0].latest_version == "1.5.0"
+
+    async def test_pinned_different_version_installed(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version differs from installed -> OUTDATED, pinned=True."""
+        # Arrange
+        config = _make_config(tmp_path)
+        file_path = tmp_path / "mods" / "sodium.jar"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("content")
+
+        installed = _make_installed_file(
+            "sodium",
+            file_path=file_path,
+            version_number="1.4.0",
+            sha512="oldhash" * 20,
+        )
+        manager_temp = ProjectManager(config)
+        state = StateFile(version=1, files={"sodium": installed})
+        await manager_temp._save_state(state)
+
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="pinned-id",
+                    version_number="1.5.0",
+                    version_type="release",
+                    sha512="pinnedhash" * 20,
+                )
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                        version="1.5.0",
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.OUTDATED
+        assert results[0].pinned is True
+        assert results[0].current_version == "1.4.0"
+        assert results[0].latest_version == "1.5.0"
+
+    async def test_pinned_version_not_found(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version not found -> NOT_COMPATIBLE, pinned=True, error set."""
+        # Arrange
+        config = _make_config(tmp_path)
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="other-id",
+                    version_number="1.0.0",
+                    version_type="release",
+                    sha512="otherhash" * 20,
+                )
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                        version="1.5.0",
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.NOT_COMPATIBLE
+        assert results[0].pinned is True
+        assert results[0].error is not None
+        assert "1.5.0" in results[0].error
+
+    async def test_pinned_version_not_compatible(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Pinned version exists but not compatible -> NOT_COMPATIBLE, pinned=True."""
+        # Arrange
+        config = _make_config(tmp_path)
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                {
+                    "id": "pinned-id",
+                    "project_id": "AANobbMI",
+                    "version_number": "1.5.0",
+                    "version_type": "release",
+                    "game_versions": ["1.20.1"],  # Not compatible with 1.21.4
+                    "loaders": ["fabric"],
+                    "files": [
+                        {
+                            "url": "https://cdn.modrinth.com/sodium.jar",
+                            "filename": "sodium.jar",
+                            "size": 1024,
+                            "hashes": {"sha512": "pinnedhash" * 20},
+                            "primary": True,
+                        }
+                    ],
+                    "dependencies": [],
+                    "date_published": "2024-01-15T10:30:00Z",
+                }
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                        version="1.5.0",
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.NOT_COMPATIBLE
+        assert results[0].pinned is True
+        assert results[0].error is not None
+
+    async def test_not_pinned_uses_existing_logic(
+        self,
+        tmp_path: Path,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Non-pinned project uses existing logic (regression test)."""
+        # Arrange
+        config = _make_config(tmp_path)
+        httpx_mock.add_response(
+            url="https://api.modrinth.com/v2/project/sodium/version",
+            json=[
+                _make_version_payload(
+                    version_id="latest-id",
+                    version_number="2.0.0",
+                    version_type="release",
+                    sha512="latesthash" * 20,
+                )
+            ],
+        )
+
+        # Act
+        async with ProjectManager(config) as manager:
+            results = await manager.check_updates(
+                [
+                    ProjectConfig(
+                        slug="sodium",
+                        project_type=ProjectType.MOD,
+                    )
+                ]
+            )
+
+        # Assert
+        assert results[0].status == InstallStatus.NOT_INSTALLED
+        assert results[0].pinned is False
+        assert results[0].latest_version == "2.0.0"
 
 
 class TestApplyUpdates:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -476,6 +476,37 @@ class TestUpdateCheckResult:
         assert result.current_file is None
         assert result.latest_version_id is None
 
+    def test_pinned_field_defaults_to_false(self) -> None:
+        """UpdateCheckResult.pinned defaults to False."""
+
+        result = UpdateCheckResult(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            status=InstallStatus.INSTALLED,
+            current_version="0.6.0",
+            current_file=None,
+            latest_version="0.6.0",
+            latest_file=None,
+        )
+
+        assert result.pinned is False
+
+    def test_pinned_field_can_be_set_to_true(self) -> None:
+        """UpdateCheckResult.pinned can be set to True."""
+
+        result = UpdateCheckResult(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            status=InstallStatus.INSTALLED,
+            current_version="0.6.0",
+            current_file=None,
+            latest_version="0.6.0",
+            latest_file=None,
+            pinned=True,
+        )
+
+        assert result.pinned is True
+
 
 class TestStateFile:
     """Tests for StateFile model."""

--- a/tests/unit/tui/screens/test_search.py
+++ b/tests/unit/tui/screens/test_search.py
@@ -175,31 +175,50 @@ async def test_search_screen_add_project(make_search_hit) -> None:
         limit=MODRINTH_SEARCH_LIMIT,
     )
 
+    from pathlib import Path
+
+    from mcpax.core.models import AppConfig, Loader
+
+    mock_config = AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        minecraft_dir=Path("~/.minecraft"),
+    )
+
     with (
         patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
         patch("mcpax.tui.screens.search.load_projects") as mock_load,
         patch("mcpax.tui.screens.search.save_projects") as mock_save,
+        patch("mcpax.tui.screens.search.load_config") as mock_load_config,
     ):
         mock_client = AsyncMock()
         mock_client.search = AsyncMock(return_value=mock_search_result)
         mock_client_class.return_value.__aenter__.return_value = mock_client
         mock_load.return_value = []
+        mock_load_config.return_value = mock_config
 
         app = TestApp()
-        async with app.run_test() as pilot:
-            # Wait for worker to complete
-            await app.workers.wait_for_complete()
 
-            # Press 'a' to add selected project
-            await pilot.press("a")
-            await pilot.pause()
+        from mcpax.tui.screens.version_select import VERSION_SELECT_LATEST
 
-            # Verify save_projects was called
-            mock_save.assert_called_once()
-            saved_projects = mock_save.call_args[0][0]
-            assert len(saved_projects) == 1
-            assert saved_projects[0].slug == "sodium"
-            assert saved_projects[0].project_type == ProjectType.MOD
+        # Mock push_screen_wait to return VERSION_SELECT_LATEST
+        with patch.object(
+            app, "push_screen_wait", new=AsyncMock(return_value=VERSION_SELECT_LATEST)
+        ):
+            async with app.run_test() as pilot:
+                # Wait for worker to complete
+                await app.workers.wait_for_complete()
+
+                # Press 'a' to add selected project
+                await pilot.press("a")
+                await app.workers.wait_for_complete()
+
+                # Verify save_projects was called
+                mock_save.assert_called_once()
+                saved_projects = mock_save.call_args[0][0]
+                assert len(saved_projects) == 1
+                assert saved_projects[0].slug == "sodium"
+                assert saved_projects[0].project_type == ProjectType.MOD
 
 
 @pytest.mark.asyncio
@@ -292,3 +311,64 @@ async def test_search_screen_add_project_with_invalid_config(make_search_hit) ->
 
             # Verify save_projects was NOT called (config error)
             mock_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_screen_cancel_version_select(make_search_hit) -> None:
+    """Test that cancelling version selection does not add the project."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(SearchScreen(query="sodium", project_type=None))
+
+    mock_search_result = SearchResult(
+        hits=[
+            make_search_hit("sodium", "Sodium", ProjectType.MOD, 3000000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    from pathlib import Path
+
+    from mcpax.core.models import AppConfig, Loader
+
+    mock_config = AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        minecraft_dir=Path("~/.minecraft"),
+    )
+
+    with (
+        patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
+        patch("mcpax.tui.screens.search.load_projects") as mock_load,
+        patch("mcpax.tui.screens.search.save_projects") as mock_save,
+        patch("mcpax.tui.screens.search.load_config") as mock_load_config,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_load.return_value = []
+        mock_load_config.return_value = mock_config
+
+        from mcpax.tui.screens.version_select import VERSION_SELECT_CANCELLED
+
+        app = TestApp()
+
+        # Mock push_screen_wait to return VERSION_SELECT_CANCELLED
+        with patch.object(
+            app,
+            "push_screen_wait",
+            new=AsyncMock(return_value=VERSION_SELECT_CANCELLED),
+        ):
+            async with app.run_test() as pilot:
+                # Wait for worker to complete
+                await app.workers.wait_for_complete()
+
+                # Press 'a' to add selected project
+                await pilot.press("a")
+                await app.workers.wait_for_complete()
+
+                # Verify save_projects was NOT called (user cancelled)
+                mock_save.assert_not_called()

--- a/tests/unit/tui/screens/test_version_select.py
+++ b/tests/unit/tui/screens/test_version_select.py
@@ -1,0 +1,117 @@
+"""Tests for version selection screen."""
+
+from datetime import UTC, datetime
+
+from mcpax.core.models import ProjectFile, ProjectType, ProjectVersion, ReleaseChannel
+from mcpax.tui.screens.version_select import VersionSelectScreen
+
+
+class TestVersionSelectScreen:
+    """Tests for VersionSelectScreen."""
+
+    def test_screen_initialization(self) -> None:
+        """Screen can be initialized with required parameters."""
+        screen = VersionSelectScreen(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            minecraft_version="1.21.4",
+            mod_loader="fabric",
+        )
+
+        assert screen._slug == "sodium"
+        assert screen._project_type == ProjectType.MOD
+        assert screen._minecraft_version == "1.21.4"
+        assert screen._mod_loader == "fabric"
+
+    def test_screen_has_correct_bindings(self) -> None:
+        """Screen has correct key bindings."""
+        screen = VersionSelectScreen(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            minecraft_version="1.21.4",
+            mod_loader="fabric",
+        )
+
+        # Check bindings exist
+        binding_keys = [b.key for b in screen.BINDINGS]
+        assert "escape" in binding_keys
+        assert "enter" in binding_keys
+        assert "l" in binding_keys
+
+    def test_populate_table_with_duplicate_version_numbers(self) -> None:
+        """Table handles versions with duplicate numbers (different loaders)."""
+        from textual.widgets import DataTable
+
+        screen = VersionSelectScreen(
+            slug="test-mod",
+            project_type=ProjectType.MOD,
+            minecraft_version="1.20.1",
+            mod_loader="fabric",
+        )
+
+        # Create versions with same version number but different loaders
+        versions = [
+            ProjectVersion(
+                id="version-fabric",
+                project_id="test-mod",
+                version_number="1.0.0",
+                version_type=ReleaseChannel.RELEASE,
+                game_versions=["1.20.1"],
+                loaders=["fabric"],
+                files=[
+                    ProjectFile(
+                        url="https://example.com/fabric.jar",
+                        filename="mod-fabric.jar",
+                        size=1000,
+                        hashes={"sha512": "abc123"},
+                        primary=True,
+                    )
+                ],
+                dependencies=[],
+                date_published=datetime.now(tz=UTC),
+            ),
+            ProjectVersion(
+                id="version-forge",
+                project_id="test-mod",
+                version_number="1.0.0",
+                version_type=ReleaseChannel.RELEASE,
+                game_versions=["1.20.1"],
+                loaders=["forge"],
+                files=[
+                    ProjectFile(
+                        url="https://example.com/forge.jar",
+                        filename="mod-forge.jar",
+                        size=2000,
+                        hashes={"sha512": "def456"},
+                        primary=True,
+                    )
+                ],
+                dependencies=[],
+                date_published=datetime.now(tz=UTC),
+            ),
+        ]
+
+        # Create a mock DataTable
+        from unittest.mock import MagicMock
+
+        mock_table = MagicMock(spec=DataTable)
+        screen.query_one = MagicMock(return_value=mock_table)  # type: ignore[assignment]
+
+        # Populate table should not raise DuplicateKey error
+        screen._populate_table(versions)
+
+        # Verify table.add_row was called twice with different keys
+        assert mock_table.add_row.call_count == 2
+
+        # Verify that keys are different (version IDs)
+        calls = mock_table.add_row.call_args_list
+        key1 = calls[0][1]["key"]
+        key2 = calls[1][1]["key"]
+        assert key1 != key2
+        assert key1 == "version-fabric"
+        assert key2 == "version-forge"
+
+        # Verify versions mapping is populated
+        assert len(screen._versions) == 2
+        assert "version-fabric" in screen._versions
+        assert "version-forge" in screen._versions


### PR DESCRIPTION
## 概要

プロジェクトのバージョンを特定のバージョンに固定できる「バージョンピニング」機能を実装しました。──
の機能により、常に最新バージョンではなく、安定動作が確認できた特定バージョンを維持できるようにな
ます。

## 関連 Issue

Closes # 94

## 変更種別

- [x] 新機能(feat)
- [ ] バグ修正(fix)
- [ ] ドキュメント(docs)
- [ ] リファクタリング(refactor)
- [ ] テスト(test)
- [ ] その他(chore)

## 変更内容

### Core (コアロジック)

- **models.py**: `ProjectConfig.version` フィールド追加、`UpdateCheckResult.pinned` フィールド追
- **api.py**: `find_version_by_number()` メソッド追加(バージョン番号による完全一致検索)
- **manager.py**:
  - `_resolve_pinned_version()` メソッド追加(ピン留めバージョンの解決処理)
  - `get_install_status()` および `check_updates()` でピン留めロジックを分岐実装
  - ピン留めバージョンが存在しない、または非互換の場合はエラー情報を返す

### CLI

- **app.py**: `mcpax add` コマンドに `--version` オプション追加
- 更新チェック時にピン留めされたプロジェクトには `[pinned]` マーカーを表示

### TUI

- **version_select.py**: 新規画面追加
  - プロジェクト追加時にバージョン選択画面を表示
  - 互換バージョンを優先表示、非互換バージョンは灰色で表示
  - `Enter` でバージョンを選択、`L` で最新バージョン(ピン留めなし)、`Esc` でキャンセル
- **search.py**: バージョン選択画面との統合

### ドキュメント

- **README.md**: バージョンピニング機能の説明追加
- **CLAUDE.md**: プロジェクト構造ドキュメントの更新
- **docs/05_conceptual_data_model.md**: データモデルの更新
- **docs/07_function_definition.md**: バージョンピニング対応の仕様追加
- **docs/08_data_definition.md**: `UpdateCheckResult` の `pinned` フィールド説明追加

## テスト

### 単体テスト

- **test_api.py**: `find_version_by_number()` のテスト追加
  - 一致するバージョンの検索
  - 見つからない場合
  - 完全一致のみ
  - 空リスト処理

- **test_manager.py**: バージョンピニングのテストクラス追加
  - `TestGetInstallStatusPinning`: ピン留めバージョンのインストール状態テスト
  - `TestCheckUpdatesPinning`: ピン留めバージョンの更新チェックテスト
  - ピン留めバージョンが見つからない場合のエラー処理
  - ピン留めバージョンが非互換の場合のエラー処理

- **test_models.py**: `UpdateCheckResult.pinned` フィールドのテスト追加

- **test_search.py**: バージョン選択画面との統合テスト
  - 最新バージョン選択時の動作
  - キャンセル時の動作

- **test_version_select.py**: 新規テストファイル追加
  - 画面初期化テスト
  - キーバインディングテスト
  - 重複バージョン番号の処理テスト

### 実行結果

```bash
uv run pytest
# 全テストパス

チェックリスト

- コードが ../CONTRIBUTING.md のガイドラインに従っている
- uv run ruff format src tests でフォーマット済み
- uv run ruff check src tests がエラーなしで通る
- uv run ty check src がエラーなしで通る
- uv run pytest が全てパス
- 新機能の場合、テストを追加した
- 必要に応じてドキュメントを更新した

スクリーンショット(任意)

TUI のバージョン選択画面を追加したため、実行時にスクリーンショットを追加予定

補足情報(任意)

実装の詳細

バージョンピニング機能は以下の優先度で動作します:

1. ProjectConfig.version が設定されている場合、常にそのバージョンを使用
2. 設定されたバージョンが存在しない、または互換性がない場合は NOT_COMPATIBLE + エラーメッセージ
3. ピン留めされていない場合は従来通り最新の互換バージョンを使用

レビューポイント

- バージョンピニングロジックの分岐が適切か
- TUI でのバージョン選択 UX は直感的か
- エラーメッセージは分かりやすいか