### PR TITLE
feat: add UnsupportedProjectTypeError and update project type handling

### DIFF
--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -29,6 +29,7 @@ from mcpax.core.config import (
 from mcpax.core.exceptions import APIError, ProjectNotFoundError
 from mcpax.core.manager import ProjectManager
 from mcpax.core.models import (
+    INSTALLABLE_PROJECT_TYPES,
     InstallStatus,
     Loader,
     ModrinthProject,
@@ -366,6 +367,15 @@ def add(
     except APIError as e:
         console.print(f"[red]Error:[/red] API error: {e}")
         raise typer.Exit(code=1) from None
+
+    # Check if project type is supported for installation
+    if project.project_type not in INSTALLABLE_PROJECT_TYPES:
+        console.print(
+            f"[red]Error:[/red] Project type '{project.project_type.value}' "
+            f"is not supported for installation. "
+            f"Modpacks cannot be managed by mcpax."
+        )
+        raise typer.Exit(code=1)
 
     # Create project config
     project_config = ProjectConfig(

--- a/src/mcpax/core/exceptions.py
+++ b/src/mcpax/core/exceptions.py
@@ -120,3 +120,18 @@ class FileOperationError(MCPAXError):
         """
         super().__init__(message)
         self.path = path
+
+
+class UnsupportedProjectTypeError(MCPAXError):
+    """Project type is not supported for installation."""
+
+    def __init__(self, project_type: str) -> None:
+        """Initialize UnsupportedProjectTypeError.
+
+        Args:
+            project_type: Project type that is not supported
+        """
+        super().__init__(
+            f"Project type '{project_type}' is not supported for installation"
+        )
+        self.project_type = project_type

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -13,7 +13,12 @@ import httpx
 
 from mcpax.core.api import ModrinthClient
 from mcpax.core.downloader import Downloader, DownloaderConfig
-from mcpax.core.exceptions import APIError, FileOperationError, StateFileError
+from mcpax.core.exceptions import (
+    APIError,
+    FileOperationError,
+    StateFileError,
+    UnsupportedProjectTypeError,
+)
 from mcpax.core.models import (
     AppConfig,
     DownloadTask,
@@ -197,6 +202,10 @@ class ProjectManager:
 
         Returns:
             Path to target directory
+
+        Raises:
+            UnsupportedProjectTypeError: If project_type is not supported
+                for installation
         """
         type_to_dir = {
             ProjectType.MOD: (
@@ -210,7 +219,10 @@ class ProjectManager:
                 or self._config.minecraft_dir / "resourcepacks"
             ),
         }
-        return type_to_dir[project_type]
+        try:
+            return type_to_dir[project_type]
+        except KeyError:
+            raise UnsupportedProjectTypeError(project_type.value) from None
 
     async def place_file(self, src: Path, dest_dir: Path) -> Path:
         """Move downloaded file to target directory.

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -27,6 +27,16 @@ class ProjectType(StrEnum):
     RESOURCEPACK = "resourcepack"
 
 
+INSTALLABLE_PROJECT_TYPES: frozenset[ProjectType] = frozenset(
+    [
+        ProjectType.MOD,
+        ProjectType.SHADER,
+        ProjectType.RESOURCEPACK,
+    ]
+)
+"""Project types that can be installed by mcpax."""
+
+
 class ReleaseChannel(StrEnum):
     """Release channel types."""
 

--- a/src/mcpax/tui/screens/search.py
+++ b/src/mcpax/tui/screens/search.py
@@ -16,6 +16,7 @@ from mcpax.core.config import (
     save_projects,
 )
 from mcpax.core.models import (
+    INSTALLABLE_PROJECT_TYPES,
     ProjectConfig,
     ProjectType,
     SearchHit,
@@ -114,6 +115,14 @@ class SearchScreen(Screen[bool]):
         Args:
             hit: Selected search hit
         """
+        # Check if project type is supported for installation
+        if hit.project_type not in INSTALLABLE_PROJECT_TYPES:
+            self.notify(
+                f"'{hit.project_type.value}' type is not supported for installation",
+                severity="error",
+            )
+            return
+
         from mcpax.tui.screens.version_select import (
             VERSION_SELECT_CANCELLED,
             VERSION_SELECT_LATEST,
@@ -154,6 +163,14 @@ class SearchScreen(Screen[bool]):
             hit: Selected search hit to add
             version: Optional version to pin
         """
+        # Defensive check: ensure project type is supported
+        if hit.project_type not in INSTALLABLE_PROJECT_TYPES:
+            self.notify(
+                f"'{hit.project_type.value}' type is not supported for installation",
+                severity="error",
+            )
+            return
+
         try:
             projects = load_projects()
         except FileNotFoundError:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -446,6 +446,37 @@ class TestAddCommand:
         assert "already" in result.stdout.lower()
         assert "sodium" in result.stdout
 
+    def test_add_modpack_type_is_rejected(
+        self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Test that add command rejects modpack project type."""
+        # Arrange
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        runner.invoke(app, ["init", "-y"])
+
+        mock_project = ModrinthProject(
+            id="AAAAAAAA",
+            slug="test-modpack",
+            title="Test Modpack",
+            description="A test modpack",
+            project_type=ProjectType.MODPACK,
+            downloads=1000,
+            icon_url=None,
+            versions=["v1"],
+        )
+
+        with patch("mcpax.cli.app.ModrinthClient") as MockClient:
+            mock_instance = MockClient.return_value.__aenter__.return_value
+            mock_instance.get_project = AsyncMock(return_value=mock_project)
+
+            # Act
+            result = runner.invoke(app, ["add", "test-modpack"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "modpack" in result.stdout.lower()
+        assert "not supported" in result.stdout.lower()
+
     def test_add_project_no_config(
         self, tmp_path: "Path", monkeypatch: "pytest.MonkeyPatch"
     ) -> None:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,6 +11,7 @@ from mcpax.core.exceptions import (
     ProjectNotFoundError,
     RateLimitError,
     StateFileError,
+    UnsupportedProjectTypeError,
 )
 
 
@@ -115,3 +116,25 @@ class TestFileOperationError:
 
         assert str(error) == "File operation failed"
         assert error.path == path
+
+
+class TestUnsupportedProjectTypeError:
+    """Tests for UnsupportedProjectTypeError."""
+
+    def test_stores_project_type(self) -> None:
+        """UnsupportedProjectTypeError stores project_type."""
+        error = UnsupportedProjectTypeError("modpack")
+
+        assert error.project_type == "modpack"
+
+    def test_default_message(self) -> None:
+        """UnsupportedProjectTypeError has default message."""
+        error = UnsupportedProjectTypeError("modpack")
+
+        assert str(error) == "Project type 'modpack' is not supported for installation"
+
+    def test_inherits_from_mcpax_error(self) -> None:
+        """UnsupportedProjectTypeError inherits from MCPAXError."""
+        error = UnsupportedProjectTypeError("modpack")
+
+        assert isinstance(error, MCPAXError)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -9,7 +9,11 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from mcpax.core.api import ModrinthClient
-from mcpax.core.exceptions import FileOperationError, StateFileError
+from mcpax.core.exceptions import (
+    FileOperationError,
+    StateFileError,
+    UnsupportedProjectTypeError,
+)
 from mcpax.core.manager import ProjectManager
 from mcpax.core.models import (
     AppConfig,
@@ -275,6 +279,21 @@ class TestGetTargetDirectory:
 
         # Assert
         assert result == custom_mods_dir
+
+    def test_raises_unsupported_project_type_error_for_modpack(
+        self, tmp_path: Path
+    ) -> None:
+        """Raises UnsupportedProjectTypeError for MODPACK project type."""
+        # Arrange
+        config = _make_config(tmp_path)
+        manager = ProjectManager(config)
+
+        # Act & Assert
+        with pytest.raises(UnsupportedProjectTypeError) as exc_info:
+            manager.get_target_directory(ProjectType.MODPACK)
+
+        assert exc_info.value.project_type == "modpack"
+        assert "not supported for installation" in str(exc_info.value)
 
 
 class TestPlaceFile:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from mcpax.core.models import (
+    INSTALLABLE_PROJECT_TYPES,
     AppConfig,
     Dependency,
     DependencyType,
@@ -63,6 +64,40 @@ class TestProjectType:
 
         assert isinstance(ProjectType.MOD, str)
         assert ProjectType.MOD == "mod"
+
+
+class TestInstallableProjectTypes:
+    """Tests for INSTALLABLE_PROJECT_TYPES constant."""
+
+    def test_installable_project_types_is_frozenset(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES is a frozenset."""
+
+        assert isinstance(INSTALLABLE_PROJECT_TYPES, frozenset)
+
+    def test_installable_project_types_contains_mod(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES contains MOD."""
+
+        assert ProjectType.MOD in INSTALLABLE_PROJECT_TYPES
+
+    def test_installable_project_types_contains_shader(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES contains SHADER."""
+
+        assert ProjectType.SHADER in INSTALLABLE_PROJECT_TYPES
+
+    def test_installable_project_types_contains_resourcepack(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES contains RESOURCEPACK."""
+
+        assert ProjectType.RESOURCEPACK in INSTALLABLE_PROJECT_TYPES
+
+    def test_installable_project_types_does_not_contain_modpack(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES does not contain MODPACK."""
+
+        assert ProjectType.MODPACK not in INSTALLABLE_PROJECT_TYPES
+
+    def test_installable_project_types_has_exactly_three_types(self) -> None:
+        """INSTALLABLE_PROJECT_TYPES contains exactly 3 types."""
+
+        assert len(INSTALLABLE_PROJECT_TYPES) == 3
 
 
 class TestReleaseChannel:

--- a/tests/unit/tui/screens/test_search.py
+++ b/tests/unit/tui/screens/test_search.py
@@ -372,3 +372,63 @@ async def test_search_screen_cancel_version_select(make_search_hit) -> None:
 
                 # Verify save_projects was NOT called (user cancelled)
                 mock_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_screen_rejects_modpack_project(make_search_hit) -> None:
+    """Test that modpack projects cannot be added."""
+
+    class TestApp(App[None]):
+        def on_mount(self):
+            self.push_screen(SearchScreen(query="modpack", project_type=None))
+
+    mock_search_result = SearchResult(
+        hits=[
+            make_search_hit("test-modpack", "Test Modpack", ProjectType.MODPACK, 1000),
+        ],
+        total_hits=1,
+        offset=0,
+        limit=MODRINTH_SEARCH_LIMIT,
+    )
+
+    from pathlib import Path
+
+    from mcpax.core.models import AppConfig, Loader
+
+    mock_config = AppConfig(
+        minecraft_version="1.21.4",
+        mod_loader=Loader.FABRIC,
+        minecraft_dir=Path("~/.minecraft"),
+    )
+
+    with (
+        patch("mcpax.tui.screens.search.ModrinthClient") as mock_client_class,
+        patch("mcpax.tui.screens.search.load_projects") as mock_load,
+        patch("mcpax.tui.screens.search.save_projects") as mock_save,
+        patch("mcpax.tui.screens.search.load_config") as mock_load_config,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_search_result)
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_load.return_value = []
+        mock_load_config.return_value = mock_config
+
+        from mcpax.tui.screens.version_select import VERSION_SELECT_LATEST
+
+        app = TestApp()
+
+        # Mock push_screen_wait to return VERSION_SELECT_LATEST
+        with patch.object(
+            app, "push_screen_wait", new=AsyncMock(return_value=VERSION_SELECT_LATEST)
+        ):
+            async with app.run_test() as pilot:
+                # Wait for worker to complete
+                await app.workers.wait_for_complete()
+
+                # Press 'a' to add selected project
+                await pilot.press("a")
+                await app.workers.wait_for_complete()
+
+                # Verify save_projects was NOT called (modpack not supported)
+                # Because the guard should reject it before reaching save
+                mock_save.assert_not_called()


### PR DESCRIPTION
## 概要

modpack タイプのプロジェクトがインストール対象としてサポートされていないにも関わらず、`add` コマンドや
 TUI の検索画面から追加できてしまう問題を修正。`INSTALLABLE_PROJECT_TYPES` 定数と
`UnsupportedProjectTypeError` 例外を導入し、CLI・TUI・コアの各レイヤーで modpack
を明確に拒否するようにした。

## 関連 Issue

Closes #

## 変更種別

- [x] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

- `models.py`: インストール可能なプロジェクトタイプを定義する `INSTALLABLE_PROJECT_TYPES`（frozenset）を追加（MOD, SHADER, RESOURCEPACK の3種）
- `exceptions.py`: `UnsupportedProjectTypeError` 例外クラスを追加（`MCPAXError` を継承）
- `manager.py`: `get_target_directory` で未対応のプロジェクトタイプに対して `KeyError` の代わりに `UnsupportedProjectTypeError` を送出するように変更
- `cli/app.py`: `add` コマンドで Modrinth API からプロジェクト情報取得後、modpack タイプの場合はエラーメッセージを表示して終了するバリデーションを追加
- `tui/screens/search.py`: 検索画面でプロジェクト追加時に modpack タイプを拒否するガードを追加（通知メッセージ表示）

## テスト

- `test_models.py`: `INSTALLABLE_PROJECT_TYPES` の型・内容・サイズに関するテストを追加（6件）
- `test_exceptions.py`: `UnsupportedProjectTypeError`
の属性・メッセージ・継承に関するテストを追加（3件）
- `test_manager.py`: `get_target_directory` が MODPACK に対して `UnsupportedProjectTypeError` を送出することを検証するテストを追加
- `test_cli.py`: `add` コマンドが modpack タイプを拒否することを検証するテストを追加
- `test_search.py`: TUI 検索画面が modpack プロジェクトの追加を拒否することを検証するテストを追加

## チェックリスト
- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [x] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した