### PR TITLE
fix: address defensive coding issues (#100)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpax"
-version = "0.11.0"
+version = "0.11.2"
 description = "Minecraft MOD/Shader/Resource Pack manager via Modrinth API"
 readme = "README.md"
 license = "MIT"

--- a/src/mcpax/__init__.py
+++ b/src/mcpax/__init__.py
@@ -1,3 +1,3 @@
 """mcpax - Minecraft MOD/Shader/Resource Pack manager via Modrinth API."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.2"

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -168,7 +168,7 @@ def init(
         console.print("Run 'mcpax add <slug>' to add projects.")
 
     except FileExistsError as e:
-        filename = Path(str(e).split(":", 1)[1].strip()).name
+        filename = Path(e.filename).name if e.filename else str(e)
         console.print(
             f"[red]Error:[/red] {filename} already exists. Use --force to overwrite."
         )

--- a/src/mcpax/core/config.py
+++ b/src/mcpax/core/config.py
@@ -1,5 +1,6 @@
 """Configuration file handling."""
 
+import errno
 import os
 import re
 import tomllib
@@ -174,7 +175,7 @@ def generate_config(
     config_path = path or get_default_config_path()
 
     if config_path.exists() and not force:
-        raise FileExistsError(f"Config file already exists: {config_path}")
+        raise FileExistsError(errno.EEXIST, "File already exists", str(config_path))
 
     # Create parent directory if it doesn't exist
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -260,7 +261,7 @@ def generate_projects(path: Path | None = None, force: bool = False) -> Path:
     projects_path = path or get_default_projects_path()
 
     if projects_path.exists() and not force:
-        raise FileExistsError(f"Projects file already exists: {projects_path}")
+        raise FileExistsError(errno.EEXIST, "File already exists", str(projects_path))
 
     # Create parent directory if it doesn't exist
     projects_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -729,109 +729,125 @@ class ProjectManager:
         dest_dir = self._get_temp_download_dir()
         dest_dir.mkdir(parents=True, exist_ok=True)
 
-        for update in to_update:
-            if update.latest_file is None:
-                result.failed.append(
-                    FailedUpdate(slug=update.slug, error="No compatible version found")
-                )
-                continue
-
-            task = DownloadTask(
-                url=update.latest_file.url,
-                dest=dest_dir / update.latest_file.filename,
-                expected_hash=update.latest_file.hashes.get("sha512"),
-                slug=update.slug,
-                version_number=update.latest_version or "unknown",
-            )
-            tasks.append(task)
-            update_info[update.slug] = update
-
-        # Download all files
-        if tasks:
-            download_results = await self._downloader.download_all(tasks)
-
-            for download_result in download_results:
-                slug = download_result.task.slug
-                if not download_result.success:
+        try:
+            for update in to_update:
+                if update.latest_file is None:
                     result.failed.append(
                         FailedUpdate(
-                            slug=slug, error=download_result.error or "Download failed"
+                            slug=update.slug, error="No compatible version found"
                         )
                     )
                     continue
 
-                update = update_info[slug]
-                final_path: Path | None = None
+                task = DownloadTask(
+                    url=update.latest_file.url,
+                    dest=dest_dir / update.latest_file.filename,
+                    expected_hash=update.latest_file.hashes.get("sha512"),
+                    slug=update.slug,
+                    version_number=update.latest_version or "unknown",
+                )
+                tasks.append(task)
+                update_info[update.slug] = update
 
-                try:
-                    if update.latest_version_id is None:
+            # Download all files
+            if tasks:
+                download_results = await self._downloader.download_all(tasks)
+
+                for download_result in download_results:
+                    slug = download_result.task.slug
+                    if not download_result.success:
                         result.failed.append(
-                            FailedUpdate(slug=slug, error="Latest version id is None")
-                        )
-                        continue
-
-                    # Place new file
-                    target_dir = self.get_target_directory(update.project_type)
-                    if download_result.file_path is None:
-                        result.failed.append(
-                            FailedUpdate(slug=slug, error="Download path is None")
-                        )
-                        continue
-
-                    final_path = await self.place_file(
-                        download_result.file_path, target_dir
-                    )
-
-                    # Backup and delete old file after new placement succeeds
-                    if (
-                        update.current_file
-                        and update.current_file.file_path.exists()
-                        and update.current_file.file_path != final_path
-                    ):
-                        if backup:
-                            backup_path = await self.backup_file(
-                                update.current_file.file_path
+                            FailedUpdate(
+                                slug=slug,
+                                error=download_result.error or "Download failed",
                             )
-                            result.backed_up.append(backup_path)
-                        await self.delete_file(update.current_file.file_path)
-
-                    # Update state
-                    if update.latest_file is None:
-                        result.failed.append(
-                            FailedUpdate(slug=slug, error="Latest file is None")
                         )
                         continue
 
-                    installed_file = InstalledFile(
-                        slug=slug,
-                        project_type=update.project_type,
-                        filename=final_path.name,
-                        version_id=update.latest_version_id,
-                        version_number=update.latest_version or "unknown",
-                        sha512=update.latest_file.hashes.get("sha512", ""),
-                        installed_at=datetime.now(UTC),
-                        file_path=final_path,
-                    )
-                    # Update state in memory
-                    state.files[slug] = installed_file
-                    state_modified = True
-                    result.successful.append(slug)
+                    update = update_info[slug]
+                    final_path: Path | None = None
 
-                except Exception as e:
-                    if final_path and final_path.exists():
-                        try:
-                            await self.delete_file(final_path)
-                        except Exception as rollback_error:
-                            logger.error(
-                                "Failed to rollback new file %s: %s",
-                                final_path,
-                                rollback_error,
+                    try:
+                        if update.latest_version_id is None:
+                            result.failed.append(
+                                FailedUpdate(
+                                    slug=slug, error="Latest version id is None"
+                                )
                             )
-                    result.failed.append(FailedUpdate(slug=slug, error=str(e)))
+                            continue
 
-        # Save state once at the end if modified
-        if state_modified:
-            await self._save_state(state)
+                        # Place new file
+                        target_dir = self.get_target_directory(update.project_type)
+                        if download_result.file_path is None:
+                            result.failed.append(
+                                FailedUpdate(slug=slug, error="Download path is None")
+                            )
+                            continue
+
+                        final_path = await self.place_file(
+                            download_result.file_path, target_dir
+                        )
+
+                        # Backup and delete old file after new placement succeeds
+                        if (
+                            update.current_file
+                            and update.current_file.file_path.exists()
+                            and update.current_file.file_path != final_path
+                        ):
+                            if backup:
+                                backup_path = await self.backup_file(
+                                    update.current_file.file_path
+                                )
+                                result.backed_up.append(backup_path)
+                            await self.delete_file(update.current_file.file_path)
+
+                        # Update state
+                        if update.latest_file is None:
+                            result.failed.append(
+                                FailedUpdate(slug=slug, error="Latest file is None")
+                            )
+                            continue
+
+                        installed_file = InstalledFile(
+                            slug=slug,
+                            project_type=update.project_type,
+                            filename=final_path.name,
+                            version_id=update.latest_version_id,
+                            version_number=update.latest_version or "unknown",
+                            sha512=update.latest_file.hashes.get("sha512", ""),
+                            installed_at=datetime.now(UTC),
+                            file_path=final_path,
+                        )
+                        # Update state in memory
+                        state.files[slug] = installed_file
+                        state_modified = True
+                        result.successful.append(slug)
+
+                    except (
+                        FileOperationError,
+                        UnsupportedProjectTypeError,
+                        OSError,
+                    ) as e:
+                        if final_path and final_path.exists():
+                            try:
+                                await self.delete_file(final_path)
+                            except (FileOperationError, OSError) as rollback_error:
+                                logger.error(
+                                    "Failed to rollback new file %s: %s",
+                                    final_path,
+                                    rollback_error,
+                                )
+                        result.failed.append(FailedUpdate(slug=slug, error=str(e)))
+
+            # Save state once at the end if modified
+            if state_modified:
+                await self._save_state(state)
+        finally:
+            try:
+                if dest_dir.exists():
+                    shutil.rmtree(dest_dir)
+            except OSError:
+                logger.warning("Failed to clean up temporary directory: %s", dest_dir)
 
         return result
 

--- a/src/mcpax/tui/screens/search.py
+++ b/src/mcpax/tui/screens/search.py
@@ -142,6 +142,7 @@ class SearchScreen(Screen[bool]):
             project_type=hit.project_type,
             minecraft_version=config.minecraft_version,
             mod_loader=config.mod_loader.value,
+            shader_loader=config.shader_loader.value if config.shader_loader else None,
         )
 
         selected_version = await self.app.push_screen_wait(version_select_screen)

--- a/src/mcpax/tui/screens/settings.py
+++ b/src/mcpax/tui/screens/settings.py
@@ -153,12 +153,7 @@ class SettingsScreen(Screen[bool]):
 
             # Format value
             value = self._values.get(key)
-            if value is None:
-                display_value = "(not set)"
-            elif isinstance(value, bool):
-                display_value = str(value)
-            else:
-                display_value = str(value)
+            display_value = "(not set)" if value is None else str(value)
 
             # Add row
             table.add_row(display_section, label, display_value)
@@ -194,12 +189,7 @@ class SettingsScreen(Screen[bool]):
 
         # Get current value
         value = self._values.get(key)
-        if value is None:
-            current_value = ""
-        elif isinstance(value, bool):
-            current_value = str(value)
-        else:
-            current_value = str(value)
+        current_value = "" if value is None else str(value)
 
         # Push the edit modal
         self.app.push_screen(

--- a/src/mcpax/tui/screens/version_select.py
+++ b/src/mcpax/tui/screens/version_select.py
@@ -8,7 +8,7 @@ from textual.widgets import DataTable, Footer, Label, Static
 from textual.worker import Worker, WorkerState
 
 from mcpax.core.api import ModrinthClient
-from mcpax.core.models import ProjectType, ProjectVersion
+from mcpax.core.models import Loader, ProjectType, ProjectVersion, ReleaseChannel
 
 # Version selection result constants
 VERSION_SELECT_CANCELLED: None = None
@@ -30,6 +30,7 @@ class VersionSelectScreen(Screen[str | None]):
         project_type: ProjectType,
         minecraft_version: str,
         mod_loader: str,
+        shader_loader: str | None = None,
     ) -> None:
         """Initialize VersionSelectScreen.
 
@@ -38,12 +39,14 @@ class VersionSelectScreen(Screen[str | None]):
             project_type: Project type
             minecraft_version: Minecraft version for filtering
             mod_loader: Mod loader for filtering
+            shader_loader: Shader loader for filtering (optional)
         """
         super().__init__()
         self._slug = slug
         self._project_type = project_type
         self._minecraft_version = minecraft_version
         self._mod_loader = mod_loader
+        self._shader_loader = shader_loader
         self._versions: dict[str, ProjectVersion] = {}
 
     def compose(self) -> ComposeResult:
@@ -117,22 +120,22 @@ class VersionSelectScreen(Screen[str | None]):
         # Store versions mapping for later retrieval
         self._versions = {version.id: version for version in versions}
 
-        # Filter compatible versions first for better UX
-        compatible = []
-        incompatible = []
-
-        for version in versions:
-            # Check if compatible with current Minecraft version
-            is_compatible = self._minecraft_version in version.game_versions
-
-            # For mods, also check loader compatibility
-            if self._project_type == ProjectType.MOD:
-                is_compatible = is_compatible and self._mod_loader in version.loaders
-
-            if is_compatible:
-                compatible.append(version)
-            else:
-                incompatible.append(version)
+        client = ModrinthClient()
+        loader = Loader(self._mod_loader)
+        shader_loader_enum = (
+            Loader(self._shader_loader) if self._shader_loader else None
+        )
+        compatible_versions = client.filter_compatible_versions(
+            versions=versions,
+            minecraft_version=self._minecraft_version,
+            loader=loader,
+            channel=ReleaseChannel.ALPHA,  # TUI shows all channels
+            project_type=self._project_type,
+            shader_loader=shader_loader_enum,
+        )
+        compatible_ids = {v.id for v in compatible_versions}
+        compatible = [v for v in versions if v.id in compatible_ids]
+        incompatible = [v for v in versions if v.id not in compatible_ids]
 
         # Add compatible versions first (highlighted)
         for version in compatible:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -539,6 +539,27 @@ class TestGenerateConfig:
         assert loaded.mod_loader == Loader.FABRIC
         assert loaded.minecraft_dir == minecraft_dir.resolve()
 
+    def test_generate_config_file_exists_error_has_filename_attribute(
+        self, tmp_path: Path
+    ) -> None:
+        """generate_config FileExistsError has filename attribute."""
+        # Arrange
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("existing content")
+
+        # Act & Assert
+        with pytest.raises(FileExistsError) as exc_info:
+            generate_config(
+                minecraft_version="1.21.4",
+                mod_loader=Loader.FABRIC,
+                minecraft_dir=Path("~/.minecraft"),
+                path=config_path,
+            )
+
+        # Verify filename attribute is set
+        assert exc_info.value.filename is not None
+        assert exc_info.value.filename == str(config_path)
+
 
 class TestLoadProjects:
     """Tests for load_projects function."""
@@ -780,6 +801,22 @@ class TestGenerateProjects:
         # Assert
         content = projects_path.read_text()
         assert "existing content" not in content
+
+    def test_generate_projects_file_exists_error_has_filename_attribute(
+        self, tmp_path: Path
+    ) -> None:
+        """generate_projects FileExistsError has filename attribute."""
+        # Arrange
+        projects_path = tmp_path / "projects.toml"
+        projects_path.write_text("existing content")
+
+        # Act & Assert
+        with pytest.raises(FileExistsError) as exc_info:
+            generate_projects(path=projects_path)
+
+        # Verify filename attribute is set
+        assert exc_info.value.filename is not None
+        assert exc_info.value.filename == str(projects_path)
 
 
 class TestSaveProjects:

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -2135,6 +2135,189 @@ class TestApplyUpdatesRollback:
         assert not expected_new_path.exists()
         assert any(f.slug == "sodium" for f in result.failed)
 
+    async def test_unexpected_exception_propagates_not_caught_broadly(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unexpected exceptions propagate instead of being caught broadly."""
+        # Arrange
+        config = _make_config(tmp_path)
+
+        latest_file = ProjectFile(
+            url="https://cdn.modrinth.com/sodium.jar",
+            filename="sodium.jar",
+            size=1024,
+            hashes={"sha512": "newhash" * 20},
+            primary=True,
+        )
+        update = UpdateCheckResult(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            status=InstallStatus.NOT_INSTALLED,
+            current_version=None,
+            current_file=None,
+            latest_version="1.0.0",
+            latest_version_id="ABC123",
+            latest_file=latest_file,
+        )
+
+        download_file = tmp_path / "downloads" / latest_file.filename
+        download_file.parent.mkdir(parents=True)
+        download_file.write_text("new")
+        task = DownloadTask(
+            url=latest_file.url,
+            dest=download_file,
+            expected_hash=latest_file.hashes["sha512"],
+            slug="sodium",
+            version_number="1.0.0",
+        )
+        download_result = DownloadResult(
+            task=task,
+            success=True,
+            file_path=download_file,
+            error=None,
+        )
+
+        manager = ProjectManager(
+            config,
+            api_client=DummyApiClient(ProjectType.MOD),
+            downloader=DummyDownloader([download_result]),
+        )
+
+        # Mock get_target_directory to raise an unexpected exception
+        def get_target_directory_fail(project_type: ProjectType) -> Path:
+            raise RuntimeError("Unexpected internal error")
+
+        monkeypatch.setattr(manager, "get_target_directory", get_target_directory_fail)
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="Unexpected internal error"):
+            await manager.apply_updates([update], backup=False)
+
+    async def test_cleans_up_temp_download_dir_on_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Temporary download directory is removed after successful update."""
+        # Arrange
+        config = _make_config(tmp_path)
+
+        latest_file = ProjectFile(
+            url="https://cdn.modrinth.com/sodium.jar",
+            filename="sodium.jar",
+            size=1024,
+            hashes={"sha512": "newhash" * 20},
+            primary=True,
+        )
+        update = UpdateCheckResult(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            status=InstallStatus.NOT_INSTALLED,
+            current_version=None,
+            current_file=None,
+            latest_version="1.0.0",
+            latest_version_id="ABC123",
+            latest_file=latest_file,
+        )
+
+        temp_dir = tmp_path / ".mcpax-downloads"
+        temp_dir.mkdir(parents=True)
+        download_file = temp_dir / latest_file.filename
+        download_file.write_text("new")
+
+        task = DownloadTask(
+            url=latest_file.url,
+            dest=download_file,
+            expected_hash=latest_file.hashes["sha512"],
+            slug="sodium",
+            version_number="1.0.0",
+        )
+        download_result = DownloadResult(
+            task=task,
+            success=True,
+            file_path=download_file,
+            error=None,
+        )
+
+        manager = ProjectManager(
+            config,
+            api_client=DummyApiClient(ProjectType.MOD),
+            downloader=DummyDownloader([download_result]),
+        )
+
+        # Act
+        result = await manager.apply_updates([update], backup=False)
+
+        # Assert
+        assert result.successful == ["sodium"]
+        assert not temp_dir.exists()
+
+    async def test_cleans_up_temp_download_dir_on_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Temporary download directory is removed even on failure."""
+        # Arrange
+        config = _make_config(tmp_path)
+
+        latest_file = ProjectFile(
+            url="https://cdn.modrinth.com/sodium.jar",
+            filename="sodium.jar",
+            size=1024,
+            hashes={"sha512": "newhash" * 20},
+            primary=True,
+        )
+        update = UpdateCheckResult(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            status=InstallStatus.NOT_INSTALLED,
+            current_version=None,
+            current_file=None,
+            latest_version="1.0.0",
+            latest_version_id="ABC123",
+            latest_file=latest_file,
+        )
+
+        temp_dir = tmp_path / ".mcpax-downloads"
+        temp_dir.mkdir(parents=True)
+        download_file = temp_dir / latest_file.filename
+        download_file.write_text("new")
+
+        task = DownloadTask(
+            url=latest_file.url,
+            dest=download_file,
+            expected_hash=latest_file.hashes["sha512"],
+            slug="sodium",
+            version_number="1.0.0",
+        )
+        download_result = DownloadResult(
+            task=task,
+            success=True,
+            file_path=download_file,
+            error=None,
+        )
+
+        manager = ProjectManager(
+            config,
+            api_client=DummyApiClient(ProjectType.MOD),
+            downloader=DummyDownloader([download_result]),
+        )
+
+        # Mock place_file to fail
+        async def place_file_fail(src: Path, dest_dir: Path) -> Path:
+            raise FileOperationError("placement failed", path=src)
+
+        monkeypatch.setattr(manager, "place_file", place_file_fail)
+
+        # Act
+        result = await manager.apply_updates([update], backup=False)
+
+        # Assert
+        assert any(f.slug == "sodium" for f in result.failed)
+        assert not temp_dir.exists()
+
     def test_returns_false_when_latest_is_none(self, tmp_path: Path) -> None:
         """Returns False when latest is None."""
         # Arrange

--- a/tests/unit/tui/screens/test_version_select.py
+++ b/tests/unit/tui/screens/test_version_select.py
@@ -115,3 +115,26 @@ class TestVersionSelectScreen:
         assert len(screen._versions) == 2
         assert "version-fabric" in screen._versions
         assert "version-forge" in screen._versions
+
+    def test_shader_loader_parameter_is_stored(self) -> None:
+        """Screen stores shader_loader parameter correctly."""
+        screen = VersionSelectScreen(
+            slug="complementary-shaders",
+            project_type=ProjectType.SHADER,
+            minecraft_version="1.21.4",
+            mod_loader="fabric",
+            shader_loader="iris",
+        )
+
+        assert screen._shader_loader == "iris"
+
+    def test_shader_loader_parameter_defaults_to_none(self) -> None:
+        """Screen defaults shader_loader to None when not provided."""
+        screen = VersionSelectScreen(
+            slug="sodium",
+            project_type=ProjectType.MOD,
+            minecraft_version="1.21.4",
+            mod_loader="fabric",
+        )
+
+        assert screen._shader_loader is None


### PR DESCRIPTION
## 概要

Issue #100で指摘された防御的コーディングの問題を修正しました。具体的には、FileExistsErrorの適切な処理
、一時ファイルのクリーンアップ保証、例外処理の具体化などを実施しています。

## 関連 Issue

Closes #100

## 変更種別

- [ ] 新機能（feat）
- [x] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

- **FileExistsError.filename属性の使用**: `generate_config`と`generate_projects`でFileExistsError発生
時にerrnoとfilenameを適切に設定し、CLI側で文字列パースではなくfilename属性を使用するように変更
- **VersionSelectScreenでfilter_compatible_versionsを再利用**:
TUI側でもModrinthClientの共通フィルタリングロジックを使用することで、コード重複を削減し一貫性を向上
- **一時ダウンロードディレクトリのクリーンアップ**: `apply_updates`メソッドにtry-finallyブロックを追加
し、成功/失敗に関わらず一時ディレクトリが確実に削除されるように変更
- **例外キャッチの具体化**: `apply_updates`内のbare `except Exception`を削除し、`FileOperationError`、
`UnsupportedProjectTypeError`、`OSError`など具体的な例外型のみをキャッチするように変更
- **冗長なコードの削除**:
SettingsScreenの三項演算子を単純化し、`if-else`の分岐内で直接代入するように変更

## テスト

以下のテストを追加・実施しました：

- `test_generate_config_file_exists_error_has_filename_attribute`:
FileExistsErrorのfilename属性が正しく設定されることを検証
- `test_generate_projects_file_exists_error_has_filename_attribute`: 同上（projects.toml版）
- `test_unexpected_exception_propagates_not_caught_broadly`:
想定外の例外が広範なcatchで捕捉されずに伝播することを検証
- `test_cleans_up_temp_download_dir_on_success`: 更新成功時に一時ディレクトリが削除されることを検証
- `test_cleans_up_temp_download_dir_on_failure`: 更新失敗時でも一時ディレクトリが削除されることを検証
- `test_shader_loader_parameter_is_stored`:
VersionSelectScreenのshader_loaderパラメータが正しく保存されることを検証
- `test_shader_loader_parameter_defaults_to_none`:
shader_loader未指定時にNoneがデフォルト値になることを検証

全テストがパスすることを確認しました：
```bash
uv run pytest

チェックリスト

- コードが ../CONTRIBUTING.md のガイドラインに従っている
- uv run ruff format src tests でフォーマット済み
- uv run ruff check src tests がエラーなしで通る
- uv run ty check src がエラーなしで通る
- uv run pytest が全てパス
- 新機能の場合、テストを追加した
- 必要に応じてドキュメントを更新した

補足情報

この修正により、以下の点で防御的コーディングが改善されました：
- リソース管理: finally節による確実なクリーンアップ
- エラー情報: FileExistsErrorに適切なメタデータを付与
- 例外処理: 具体的な例外型のみをキャッチし、想定外のエラーは伝播させる
- コードの一貫性: 共通ロジックの再利用による保守性向上