### PR TITLE
refactor: コード品質の改善（パターン重複・エイリアス整理・関数分割）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ docstring-code-format = true
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-markers = ["integration: marks tests as integration tests"]
 addopts = "--cov=src/mcpax --cov-report=term-missing"
 
 [build-system]

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -541,14 +541,6 @@ def list_projects(
         mcpax list --no-cache
         mcpax list --max-concurrency 5
     """
-    # Check if config.toml exists
-    config_path = get_default_config_path()
-    if not config_path.exists():
-        console.print(
-            "[red]Error:[/red] config.toml not found. Run 'mcpax init' first."
-        )
-        raise typer.Exit(code=1)
-
     # Load config
     try:
         config = load_config()

--- a/src/mcpax/cli/app.py
+++ b/src/mcpax/cli/app.py
@@ -58,7 +58,53 @@ app.add_typer(config_app, name="config")
 DEFAULT_MINECRAFT_VERSION = "1.21.4"
 DEFAULT_MINECRAFT_DIR = Path("~/.minecraft")
 VALID_PROJECT_TYPES = {"mod", "modpack", "shader", "resourcepack"}
+VALID_STATUS_FILTERS = {"installed", "not-installed", "outdated"}
 console = Console()
+
+
+def _validate_list_options(
+    type_filter: str | None,
+    status_filter: str | None,
+    no_update: bool,
+    max_concurrency: int,
+) -> str | None:
+    """Validate list command options. Returns error message or None if valid."""
+    if type_filter is not None and type_filter.lower() not in VALID_PROJECT_TYPES:
+        return (
+            f"Invalid type '{type_filter}'. "
+            f"Must be one of: {', '.join(VALID_PROJECT_TYPES)}."
+        )
+
+    if status_filter is not None:
+        status_filter_lower = status_filter.lower()
+        if status_filter_lower not in VALID_STATUS_FILTERS:
+            return (
+                f"Invalid status '{status_filter}'. "
+                f"Must be one of: {', '.join(VALID_STATUS_FILTERS)}."
+            )
+        if no_update and status_filter_lower == "outdated":
+            return "--status outdated is not supported with --no-update."
+
+    if max_concurrency < 1:
+        return "--max-concurrency must be a positive integer."
+
+    return None
+
+
+def _format_list_json(results: list[dict]) -> str:
+    """Format list results as a JSON string."""
+    json_data = [
+        {
+            "slug": p["slug"],
+            "title": p["title"],
+            "type": p["type"].value,
+            "status": p["status"].value,
+            "current_version": p["current_version"],
+            "latest_version": p["latest_version"],
+        }
+        for p in results
+    ]
+    return json.dumps(json_data, indent=2, ensure_ascii=False)
 
 
 def version_callback(value: bool) -> None:
@@ -550,31 +596,12 @@ def list_projects(
         )
         raise typer.Exit(code=1) from None
 
-    # Validate type filter
-    if type_filter is not None and type_filter.lower() not in VALID_PROJECT_TYPES:
-        console.print(
-            f"[red]Error:[/red] Invalid type '{type_filter}'. "
-            f"Must be one of: {', '.join(VALID_PROJECT_TYPES)}."
-        )
-        raise typer.Exit(code=1)
-
-    # Validate status filter
-    valid_statuses = {"installed", "not-installed", "outdated"}
-    if status_filter is not None and status_filter.lower() not in valid_statuses:
-        console.print(
-            f"[red]Error:[/red] Invalid status '{status_filter}'. "
-            f"Must be one of: {', '.join(valid_statuses)}."
-        )
-        raise typer.Exit(code=1)
-
-    if no_update and status_filter is not None and status_filter.lower() == "outdated":
-        console.print(
-            "[red]Error:[/red] --status outdated is not supported with --no-update."
-        )
-        raise typer.Exit(code=1)
-
-    if max_concurrency < 1:
-        console.print("[red]Error:[/red] --max-concurrency must be a positive integer.")
+    # Validate options
+    validation_error = _validate_list_options(
+        type_filter, status_filter, no_update, max_concurrency
+    )
+    if validation_error is not None:
+        console.print(f"[red]Error:[/red] {validation_error}")
         raise typer.Exit(code=1)
 
     # Load existing projects
@@ -694,18 +721,7 @@ def list_projects(
 
     # Output in JSON format
     if json_output:
-        json_data = [
-            {
-                "slug": p["slug"],
-                "title": p["title"],
-                "type": p["type"].value,
-                "status": p["status"].value,
-                "current_version": p["current_version"],
-                "latest_version": p["latest_version"],
-            }
-            for p in project_info_list
-        ]
-        console.print(json.dumps(json_data, indent=2, ensure_ascii=False))
+        console.print(_format_list_json(project_info_list))
         raise typer.Exit(code=0)
 
     # Group by project type

--- a/src/mcpax/core/__init__.py
+++ b/src/mcpax/core/__init__.py
@@ -4,7 +4,6 @@ from mcpax.core.api import ModrinthClient, RateLimitInfo
 from mcpax.core.exceptions import (
     APIError,
     MCPAXError,
-    McpaxError,  # Backward compatibility alias
     ProjectNotFoundError,
     RateLimitError,
 )
@@ -14,7 +13,6 @@ __all__ = [
     "RateLimitInfo",
     "APIError",
     "MCPAXError",
-    "McpaxError",  # Backward compatibility (deprecated)
     "ProjectNotFoundError",
     "RateLimitError",
 ]

--- a/src/mcpax/core/config.py
+++ b/src/mcpax/core/config.py
@@ -15,17 +15,17 @@ from .models import AppConfig, Loader, ProjectConfig, ProjectType, ReleaseChanne
 APP_NAME = "mcpax"
 MINECRAFT_VERSION_PATTERN = re.compile(r"^\d+\.\d+(\.\d+)?(-\w+)?$")
 
-# Key mapping for config command
-CONFIG_KEY_MAP: dict[str, tuple[str, str]] = {
-    "minecraft.version": ("minecraft", "version"),
-    "minecraft.mod_loader": ("minecraft", "mod_loader"),
-    "minecraft.shader_loader": ("minecraft", "shader_loader"),
-    "paths.minecraft_dir": ("paths", "minecraft_dir"),
-    "paths.mods_dir": ("paths", "mods_dir"),
-    "paths.shaders_dir": ("paths", "shaders_dir"),
-    "paths.resourcepacks_dir": ("paths", "resourcepacks_dir"),
-    "download.max_concurrent": ("download", "max_concurrent"),
-    "download.verify_hash": ("download", "verify_hash"),
+# Key mapping for config command: key -> (section, field, type)
+CONFIG_KEY_MAP: dict[str, tuple[str, str, type]] = {
+    "minecraft.version": ("minecraft", "version", str),
+    "minecraft.mod_loader": ("minecraft", "mod_loader", str),
+    "minecraft.shader_loader": ("minecraft", "shader_loader", str),
+    "paths.minecraft_dir": ("paths", "minecraft_dir", str),
+    "paths.mods_dir": ("paths", "mods_dir", str),
+    "paths.shaders_dir": ("paths", "shaders_dir", str),
+    "paths.resourcepacks_dir": ("paths", "resourcepacks_dir", str),
+    "download.max_concurrent": ("download", "max_concurrent", int),
+    "download.verify_hash": ("download", "verify_hash", bool),
 }
 
 
@@ -369,7 +369,7 @@ def get_config_value(key: str, path: Path | None = None) -> str | int | bool | N
     if key not in CONFIG_KEY_MAP:
         return None
 
-    section, field = CONFIG_KEY_MAP[key]
+    section, field, _field_type = CONFIG_KEY_MAP[key]
 
     # Load config with tomlkit to preserve structure
     with open(config_path, encoding="utf-8") as f:
@@ -415,7 +415,7 @@ def set_config_value(key: str, value: str, path: Path | None = None) -> None:
     if key not in CONFIG_KEY_MAP:
         raise ValueError(f"Unknown config key: {key}")
 
-    section, field = CONFIG_KEY_MAP[key]
+    section, field, field_type = CONFIG_KEY_MAP[key]
 
     # Load config with tomlkit to preserve structure
     with open(config_path, encoding="utf-8") as f:
@@ -425,13 +425,11 @@ def set_config_value(key: str, value: str, path: Path | None = None) -> None:
     if section not in doc:
         doc[section] = tomlkit.table()
 
-    # Convert value to appropriate type based on field
+    # Convert value to appropriate type based on field_type
     converted_value: str | int | bool
-    if field == "max_concurrent":
-        # Integer field
+    if field_type is int:
         converted_value = int(value)
-    elif field == "verify_hash":
-        # Boolean field
+    elif field_type is bool:
         value_lower = value.lower()
         if value_lower in ("true", "1", "yes"):
             converted_value = True
@@ -440,7 +438,6 @@ def set_config_value(key: str, value: str, path: Path | None = None) -> None:
         else:
             raise ValueError(f"Invalid boolean value: {value}")
     else:
-        # String field
         converted_value = value
 
     # Set the value
@@ -474,7 +471,7 @@ def get_all_config_values(
         doc = tomlkit.load(f)
 
     result: dict[str, str | int | bool | None] = {}
-    for key, (section, field) in CONFIG_KEY_MAP.items():
+    for key, (section, field, _field_type) in CONFIG_KEY_MAP.items():
         value = None
         section_data = doc.get(section)
         if isinstance(section_data, dict):

--- a/src/mcpax/core/exceptions.py
+++ b/src/mcpax/core/exceptions.py
@@ -7,10 +7,6 @@ class MCPAXError(Exception):
     """Base exception for all mcpax errors."""
 
 
-# Backward compatibility alias (deprecated)
-McpaxError = MCPAXError
-
-
 class APIError(MCPAXError):
     """General API error."""
 

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -38,10 +38,6 @@ from mcpax.core.models import (
 
 logger = logging.getLogger(__name__)
 
-# Type alias for update info mapping
-UpdateInfo = UpdateCheckResult
-
-
 class ProjectManager:
     """Orchestrates project installation, updates, and state management."""
 
@@ -751,7 +747,7 @@ class ProjectManager:
 
         # Create download tasks
         tasks: list[DownloadTask] = []
-        update_info: dict[str, UpdateInfo] = {}
+        update_info: dict[str, UpdateCheckResult] = {}
 
         # Process project results and create download tasks
         dest_dir = self._get_temp_download_dir()

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -418,10 +418,7 @@ class ProjectManager:
                 return InstallStatus.NOT_COMPATIBLE
 
             # Find primary file hash
-            primary_file = next(
-                (f for f in latest.files if f.primary),
-                latest.files[0] if latest.files else None,
-            )
+            primary_file = latest.get_primary_file()
             if (
                 primary_file
                 and installed.sha512.lower()
@@ -558,10 +555,7 @@ class ProjectManager:
                 title=title,
             )
 
-        primary_file = next(
-            (f for f in latest.files if f.primary),
-            latest.files[0] if latest.files else None,
-        )
+        primary_file = latest.get_primary_file()
 
         if installed is None:
             status = InstallStatus.NOT_INSTALLED
@@ -686,10 +680,7 @@ class ProjectManager:
             )
 
         # Compatible pinned version found
-        primary_file = next(
-            (f for f in pinned_version.files if f.primary),
-            pinned_version.files[0] if pinned_version.files else None,
-        )
+        primary_file = pinned_version.get_primary_file()
 
         if installed is None:
             status = InstallStatus.NOT_INSTALLED

--- a/src/mcpax/core/manager.py
+++ b/src/mcpax/core/manager.py
@@ -38,6 +38,7 @@ from mcpax.core.models import (
 
 logger = logging.getLogger(__name__)
 
+
 class ProjectManager:
     """Orchestrates project installation, updates, and state management."""
 

--- a/src/mcpax/core/models.py
+++ b/src/mcpax/core/models.py
@@ -151,6 +151,13 @@ class ProjectVersion(BaseModel):
     dependencies: list[Dependency]
     date_published: datetime
 
+    def get_primary_file(self) -> ProjectFile | None:
+        """Return the primary file, or the first file if none is marked primary."""
+        return next(
+            (f for f in self.files if f.primary),
+            self.files[0] if self.files else None,
+        )
+
 
 class SearchHit(BaseModel):
     """A single search result from Modrinth API."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,0 @@
-"""Integration tests for mcpax."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2039,6 +2039,114 @@ class TestListCommand:
         assert "→" in result.stdout or "0.5.0" in result.stdout
 
 
+class TestValidateListOptions:
+    """Tests for _validate_list_options helper function."""
+
+    def test_valid_options_returns_none(self) -> None:
+        """_validate_list_options returns None when all options are valid."""
+        from mcpax.cli.app import _validate_list_options
+
+        result = _validate_list_options(
+            type_filter="mod",
+            status_filter="installed",
+            no_update=False,
+            max_concurrency=5,
+        )
+
+        assert result is None
+
+    def test_invalid_type_filter_returns_error(self) -> None:
+        """_validate_list_options returns error message for invalid type."""
+        from mcpax.cli.app import _validate_list_options
+
+        result = _validate_list_options(
+            type_filter="invalid",
+            status_filter=None,
+            no_update=False,
+            max_concurrency=5,
+        )
+
+        assert result is not None
+        assert "invalid" in result.lower() or "type" in result.lower()
+
+    def test_invalid_status_filter_returns_error(self) -> None:
+        """_validate_list_options returns error message for invalid status."""
+        from mcpax.cli.app import _validate_list_options
+
+        result = _validate_list_options(
+            type_filter=None,
+            status_filter="invalid",
+            no_update=False,
+            max_concurrency=5,
+        )
+
+        assert result is not None
+        assert "invalid" in result.lower() or "status" in result.lower()
+
+    def test_no_update_with_outdated_status_returns_error(self) -> None:
+        """_validate_list_options returns error for --no-update with outdated status."""
+        from mcpax.cli.app import _validate_list_options
+
+        result = _validate_list_options(
+            type_filter=None,
+            status_filter="outdated",
+            no_update=True,
+            max_concurrency=5,
+        )
+
+        assert result is not None
+
+    def test_invalid_max_concurrency_returns_error(self) -> None:
+        """_validate_list_options returns error when max_concurrency < 1."""
+        from mcpax.cli.app import _validate_list_options
+
+        result = _validate_list_options(
+            type_filter=None,
+            status_filter=None,
+            no_update=False,
+            max_concurrency=0,
+        )
+
+        assert result is not None
+
+
+class TestFormatListJson:
+    """Tests for _format_list_json helper function."""
+
+    def test_format_list_json_returns_json_string(self) -> None:
+        """_format_list_json returns valid JSON string."""
+        from mcpax.cli.app import _format_list_json
+        from mcpax.core.models import InstallStatus
+
+        results = [
+            {
+                "slug": "sodium",
+                "title": "Sodium",
+                "type": ProjectType.MOD,
+                "status": InstallStatus.INSTALLED,
+                "current_version": "0.5.0",
+                "latest_version": "0.5.0",
+            }
+        ]
+
+        output = _format_list_json(results)
+        parsed = json.loads(output)
+
+        assert len(parsed) == 1
+        assert parsed[0]["slug"] == "sodium"
+        assert parsed[0]["type"] == "mod"
+        assert parsed[0]["status"] == "installed"
+
+    def test_format_list_json_empty_results(self) -> None:
+        """_format_list_json handles empty results."""
+        from mcpax.cli.app import _format_list_json
+
+        output = _format_list_json([])
+        parsed = json.loads(output)
+
+        assert parsed == []
+
+
 class TestSearchCommand:
     """Tests for search command."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1163,16 +1163,17 @@ class TestConfigKeyMap:
         assert set(CONFIG_KEY_MAP.keys()) == expected_keys
 
     def test_config_key_map_values_are_tuples(self) -> None:
-        """CONFIG_KEY_MAP values are tuples of (section, field)."""
+        """CONFIG_KEY_MAP values are tuples of (section, field, type)."""
         # Arrange
         from mcpax.core.config import CONFIG_KEY_MAP
 
         # Act & Assert
         for key, value in CONFIG_KEY_MAP.items():
             assert isinstance(value, tuple), f"Value for {key} is not a tuple"
-            assert len(value) == 2, f"Value for {key} does not have 2 elements"
+            assert len(value) == 3, f"Value for {key} does not have 3 elements"
             assert isinstance(value[0], str), f"Section for {key} is not a string"
             assert isinstance(value[1], str), f"Field for {key} is not a string"
+            assert isinstance(value[2], type), f"Type for {key} is not a type"
 
     def test_config_key_map_minecraft_version(self) -> None:
         """CONFIG_KEY_MAP maps minecraft.version correctly."""
@@ -1180,7 +1181,7 @@ class TestConfigKeyMap:
         from mcpax.core.config import CONFIG_KEY_MAP
 
         # Act & Assert
-        assert CONFIG_KEY_MAP["minecraft.version"] == ("minecraft", "version")
+        assert CONFIG_KEY_MAP["minecraft.version"] == ("minecraft", "version", str)
 
     def test_config_key_map_download_verify_hash(self) -> None:
         """CONFIG_KEY_MAP maps download.verify_hash correctly."""
@@ -1188,7 +1189,11 @@ class TestConfigKeyMap:
         from mcpax.core.config import CONFIG_KEY_MAP
 
         # Act & Assert
-        assert CONFIG_KEY_MAP["download.verify_hash"] == ("download", "verify_hash")
+        assert CONFIG_KEY_MAP["download.verify_hash"] == (
+            "download",
+            "verify_hash",
+            bool,
+        )
 
 
 class TestGetConfigValue:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -393,6 +393,56 @@ class TestProjectVersion:
         assert version.dependencies == [dependency]
         assert version.date_published == date_published
 
+    def _make_version(self, files: list[ProjectFile]) -> ProjectVersion:
+        return ProjectVersion(
+            id="ABC123",
+            project_id="AANobbMI",
+            version_number="0.6.0",
+            version_type=ReleaseChannel.RELEASE,
+            game_versions=["1.21.4"],
+            loaders=["fabric"],
+            files=files,
+            dependencies=[],
+            date_published=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+        )
+
+    def _make_file(self, filename: str, primary: bool) -> ProjectFile:
+        return ProjectFile(
+            url=f"https://cdn.modrinth.com/data/{filename}",
+            filename=filename,
+            size=1000,
+            hashes={"sha512": "abc123"},
+            primary=primary,
+        )
+
+    def test_get_primary_file_returns_primary_file(self) -> None:
+        """get_primary_file returns the file marked as primary."""
+        primary = self._make_file("primary.jar", primary=True)
+        secondary = self._make_file("secondary.jar", primary=False)
+        version = self._make_version([secondary, primary])
+
+        result = version.get_primary_file()
+
+        assert result is primary
+
+    def test_get_primary_file_returns_first_when_no_primary(self) -> None:
+        """get_primary_file returns first file when none is marked primary."""
+        first = self._make_file("first.jar", primary=False)
+        second = self._make_file("second.jar", primary=False)
+        version = self._make_version([first, second])
+
+        result = version.get_primary_file()
+
+        assert result is first
+
+    def test_get_primary_file_returns_none_when_no_files(self) -> None:
+        """get_primary_file returns None when files list is empty."""
+        version = self._make_version([])
+
+        result = version.get_primary_file()
+
+        assert result is None
+
 
 class TestSearchHit:
     """Tests for SearchHit model."""


### PR DESCRIPTION
## 概要

`list_projects` コマンドのコード品質改善を中心としたリファクタリング。未使用コードの削除、ヘルパー関
数の抽出、型メタデータの導入により、コードの保守性・テスト容易性を向上させた。

## 関連 Issue

Closes #102 

## 変更種別

- [ ] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [x] リファクタリング（refactor）
- [x] テスト（test）
- [x] その他（chore）

## 変更内容

- **未使用コードの削除**
  - `McpaxError` の後方互換エイリアスを削除
  - `UpdateInfo` 型エイリアスを `manager.py` から削除
  - 空のインテグレーションテストディレクトリと未使用マーカーを削除

- **モデル改善**
  - `ProjectVersion` モデルに `get_primary_file` メソッドを抽出し、ファイル取得ロジックをカプセル化

- **設定関連の改善**
  - `CONFIG_KEY_MAP` に型メタデータを追加し、ハードコードされたフィールドチェックを除去
  - `list_projects` 内の冗長な設定存在チェックを除去

- **`list_projects` のヘルパー関数抽出**
  - `_validate_list_options`: バリデーションロジックを純粋関数として抽出
  - `_format_list_json`: JSON フォーマットロジックを純粋関数として抽出
  - 両関数に対するユニットテストを追加

- **その他**
  - `manager.py` のクラス定義前の空行を修正

## テスト

- `TestValidateListOptions`: 5 テストケース（正常系、無効な type/status/concurrency、no-update +
outdated の組み合わせ）
- `TestFormatListJson`: 2 テストケース（正常系、空リスト）
- 既存テストへの影響なし

## チェックリスト

- [x] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [x] `uv run ruff format src tests` でフォーマット済み
- [x] `uv run ruff check src tests` がエラーなしで通る
- [x] `uv run ty check src` がエラーなしで通る
- [x] `uv run pytest` が全てパス
- [ ] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した