### PR TITLE
perf(tests): reduce test suite runtime from 20s to ~6s

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,10 +40,15 @@ lint:
 typecheck:
     uv run ty check src
 
-# Run tests (pass args: just test -v)
+# Run tests in parallel (pass extra args: just test -v)
 [group('dev')]
 test *args:
-    uv run pytest {{ args }}
+    uv run pytest -n auto {{ args }}
+
+# Run tests without parallelism for pdb/breakpoint() debugging
+[group('dev')]
+test-debug *args:
+    uv run pytest -n0 {{ args }}
 
 # Run all quality checks (format, lint, typecheck, test)
 [group('dev')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "module"
 addopts = "--cov=src/mcpax --cov-report=term-missing -n auto"
+# To debug with pdb/breakpoint(), override parallelism: pytest -n0
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "ruff>=0.8",
     "ty>=0.0.1a6",
     "pre-commit>=4.0",
+    "pytest-xdist>=3.8.0",
 ]
 tui = ["textual>=0.50"]
 
@@ -43,8 +44,8 @@ docstring-code-format = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
-addopts = "--cov=src/mcpax --cov-report=term-missing"
+asyncio_default_fixture_loop_scope = "module"
+addopts = "--cov=src/mcpax --cov-report=term-missing -n auto"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ docstring-code-format = true
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "module"
-addopts = "--cov=src/mcpax --cov-report=term-missing -n auto"
-# To debug with pdb/breakpoint(), override parallelism: pytest -n0
+addopts = "--cov=src/mcpax --cov-report=term-missing"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,19 +62,19 @@ def fixed_terminal_width(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LINES", "50")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fixtures_dir() -> Path:
     """Return the path to the fixtures directory."""
     return Path(__file__).parent / "fixtures"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sample_config(fixtures_dir: Path) -> Path:
     """Return the path to the sample config.toml."""
     return fixtures_dir / "config.toml"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sample_projects(fixtures_dir: Path) -> Path:
     """Return the path to the sample projects.toml."""
     return fixtures_dir / "projects.toml"

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,9 +1,9 @@
 """Tests for cache.py."""
 
 import json
-import time
 from pathlib import Path
 
+import mcpax.core.cache
 from mcpax.core.cache import ApiCache
 
 
@@ -186,16 +186,19 @@ class TestApiCacheBasicFunctionality:
         # Assert
         assert result == project_data
 
-    def test_cache_respects_ttl(self, tmp_path: Path) -> None:
+    def test_cache_respects_ttl(self, tmp_path: Path, monkeypatch) -> None:
         """Cache entries should expire after TTL."""
         # Arrange
+        fake_now = [1000.0]
+        monkeypatch.setattr(mcpax.core.cache.time, "time", lambda: fake_now[0])
+
         cache_file = tmp_path / "cache.json"
-        cache = ApiCache(cache_file, ttl_seconds=1)  # 1 second TTL
+        cache = ApiCache(cache_file, ttl_seconds=1)
         cache.set_project("sodium", {"title": "Sodium"})
         cache.flush()
 
-        # Act - wait for TTL to expire
-        time.sleep(1.1)
+        # Act - advance clock past TTL without sleeping
+        fake_now[0] += 2.0
         result = cache.get_project("sodium")
 
         # Assert - should return None after expiration

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,6 +1,7 @@
 """Tests for cache.py."""
 
 import json
+import types
 from pathlib import Path
 
 import mcpax.core.cache
@@ -188,9 +189,14 @@ class TestApiCacheBasicFunctionality:
 
     def test_cache_respects_ttl(self, tmp_path: Path, monkeypatch) -> None:
         """Cache entries should expire after TTL."""
-        # Arrange
+        # Arrange - replace the module-level time reference to avoid patching
+        # the global time.time used by asyncio internals and the test runner.
         fake_now = [1000.0]
-        monkeypatch.setattr(mcpax.core.cache.time, "time", lambda: fake_now[0])
+        monkeypatch.setattr(
+            mcpax.core.cache,
+            "time",
+            types.SimpleNamespace(time=lambda: fake_now[0]),
+        )
 
         cache_file = tmp_path / "cache.json"
         cache = ApiCache(cache_file, ttl_seconds=1)

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -32,7 +32,7 @@ def app_config() -> AppConfig:
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def make_update_check_result():
     """Create UpdateCheckResult factory fixture.
 
@@ -75,7 +75,7 @@ def make_update_check_result():
     return _make_result
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def make_search_hit():
     """Create SearchHit factory fixture.
 

--- a/tests/unit/tui/screens/test_install.py
+++ b/tests/unit/tui/screens/test_install.py
@@ -116,10 +116,14 @@ async def test_install_screen_cancel_during_installation(
 
         mock_manager = AsyncMock()
 
-        # Block indefinitely so the worker is still running when escape is pressed.
-        # worker.cancel() raises CancelledError inside the wait(), ending the task.
+        # Block until cancelled by worker.cancel() (raises CancelledError).
+        # Timeout guard: if cancellation never arrives the test fails fast
+        # instead of hanging the entire suite.
         async def blocking_apply_updates(*args, **kwargs):
-            await asyncio.Event().wait()
+            try:
+                await asyncio.wait_for(asyncio.Event().wait(), timeout=5)
+            except TimeoutError:
+                pytest.fail("Install worker was not cancelled within 5 seconds")
             return mock_update_result
 
         mock_manager.update_applier.apply_updates = blocking_apply_updates
@@ -173,10 +177,14 @@ async def test_install_screen_dismiss_after_cancel(
 
         mock_manager = AsyncMock()
 
-        # Block indefinitely so the worker is still running when escape is pressed.
-        # worker.cancel() raises CancelledError inside the wait(), ending the task.
+        # Block until cancelled by worker.cancel() (raises CancelledError).
+        # Timeout guard: if cancellation never arrives the test fails fast
+        # instead of hanging the entire suite.
         async def blocking_apply_updates(*args, **kwargs):
-            await asyncio.Event().wait()
+            try:
+                await asyncio.wait_for(asyncio.Event().wait(), timeout=5)
+            except TimeoutError:
+                pytest.fail("Install worker was not cancelled within 5 seconds")
             return mock_update_result
 
         mock_manager.update_applier.apply_updates = blocking_apply_updates

--- a/tests/unit/tui/screens/test_install.py
+++ b/tests/unit/tui/screens/test_install.py
@@ -116,12 +116,13 @@ async def test_install_screen_cancel_during_installation(
 
         mock_manager = AsyncMock()
 
-        # Make apply_updates take some time so we can cancel
-        async def slow_apply_updates(*args, **kwargs):
-            await asyncio.sleep(0.5)
+        # Block indefinitely so the worker is still running when escape is pressed.
+        # worker.cancel() raises CancelledError inside the wait(), ending the task.
+        async def blocking_apply_updates(*args, **kwargs):
+            await asyncio.Event().wait()
             return mock_update_result
 
-        mock_manager.update_applier.apply_updates = slow_apply_updates
+        mock_manager.update_applier.apply_updates = blocking_apply_updates
         mock_manager_class.return_value.__aenter__.return_value = mock_manager
         mock_manager_class.return_value.__aexit__.return_value = AsyncMock()
 
@@ -172,12 +173,13 @@ async def test_install_screen_dismiss_after_cancel(
 
         mock_manager = AsyncMock()
 
-        # Make apply_updates take some time so we can cancel
-        async def slow_apply_updates(*args, **kwargs):
-            await asyncio.sleep(0.5)
+        # Block indefinitely so the worker is still running when escape is pressed.
+        # worker.cancel() raises CancelledError inside the wait(), ending the task.
+        async def blocking_apply_updates(*args, **kwargs):
+            await asyncio.Event().wait()
             return mock_update_result
 
-        mock_manager.update_applier.apply_updates = slow_apply_updates
+        mock_manager.update_applier.apply_updates = blocking_apply_updates
         mock_manager_class.return_value.__aenter__.return_value = mock_manager
         mock_manager_class.return_value.__aexit__.return_value = AsyncMock()
 


### PR DESCRIPTION
- Replace time.sleep(1.1) in test_cache.py with monkeypatch on time.time to eliminate real-time waiting for TTL expiry
- Change asyncio_default_fixture_loop_scope from function to module to reduce per-test event loop creation overhead
- Promote fixtures_dir / sample_config / sample_projects to session scope and make/search hit factories to session scope
- Add pytest-xdist and enable -n auto for parallel test execution
- Replace asyncio.sleep(0.5) in install screen cancel tests with asyncio.Event().wait() which blocks until worker.cancel() fires CancelledError, removing 1s of artificial delay

## 概要

<!-- この PR で行った変更を簡潔に説明してください -->

## 関連 Issue

<!-- Closes #123 のように記載すると、マージ時に Issue が自動クローズされます -->

Closes #

## 変更種別

<!-- 該当するものにチェックを入れてください -->

- [ ] 新機能（feat）
- [ ] バグ修正（fix）
- [ ] ドキュメント（docs）
- [ ] リファクタリング（refactor）
- [ ] テスト（test）
- [ ] その他（chore）

## 変更内容

<!-- 変更内容の詳細を記載してください -->

-

## テスト

<!-- どのようにテストしたか記載してください -->

-

## チェックリスト

<!-- 全ての項目を確認してください -->

- [ ] コードが [CONTRIBUTING.md](../CONTRIBUTING.md) のガイドラインに従っている
- [ ] `uv run ruff format src tests` でフォーマット済み
- [ ] `uv run ruff check src tests` がエラーなしで通る
- [ ] `uv run ty check src` がエラーなしで通る
- [ ] `uv run pytest` が全てパス
- [ ] 新機能の場合、テストを追加した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット（任意）

<!-- UI の変更がある場合、スクリーンショットを添付してください -->

## 補足情報（任意）

<!-- レビュアーに伝えたい追加情報があれば記載してください -->
